### PR TITLE
cleaned up section titles, added 'Hipster Handbook' to home page, etc.

### DIFF
--- a/docs/handbook/appendix.md
+++ b/docs/handbook/appendix.md
@@ -1,4 +1,4 @@
-# OpenIndiana Handbook - Appendix
+# Hipster Handbook - Appendix
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
@@ -10,7 +10,7 @@
 < place holder for introduction content >
 
 
-## Finding help and support
+## Finding Help and Support
 
 < Place Holder for section Introduction Content >
 
@@ -47,7 +47,7 @@ We may want to revisit the FAQ and pull these changes over.
 | OpenIndiana Bug Tracker | <https://www.illumos.org/projects/openindiana/issues>
 
 
-## IPS command matrix
+## IPS Command Matrix
 
 | Task | IPS Command | apt Equivalent
 | --- | --- | ---

--- a/docs/handbook/common-tasks.md
+++ b/docs/handbook/common-tasks.md
@@ -17,7 +17,7 @@ All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/a
 
 -->
 
-# OpenIndiana Handbook - Common Tasks
+# Hipster Handbook - Common Tasks
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">

--- a/docs/handbook/getting-started.md
+++ b/docs/handbook/getting-started.md
@@ -21,11 +21,12 @@ All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/a
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
+
 <p>This is a <b>DRAFT</b> document which may contain errors!</p>
 <p>Help us improve and expand this site.</p>
 <p>Please see the <b>Contrib</b> section for more details about joining the OpenIndiana Documentation Team.</p>
-</div>
 
+</div>
 
 ## Introduction
 
@@ -36,13 +37,6 @@ While our aim is to address as many facets of OpenIndiana use and administration
 In such cases external sources of information will be provided in the form of references to other web sites, man pages, or printed books.
 
 ## Hipster Software Releases
-
-<!--
-
-The content for this section is pulled from the OpenIndiana FAQ (section 'What is the OpenIndiana Release Schedule?').
-As the FAQ evolves, try to keep this section in sync.
-
--->
 
 Approximately every six months, the OpenIndiana project releases a snapshot of the Hipster rolling release branch.
 Ideally suited for both workstations and servers, simply choose the installer type which best serves your needs.
@@ -1506,7 +1500,7 @@ Use the following steps to change the root password:
 * You should be able to login/authenticate as root now.
 
 
-## The Image Package System (IPS)
+## Image Package System (IPS)
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">

--- a/docs/handbook/getting-started.md
+++ b/docs/handbook/getting-started.md
@@ -17,7 +17,7 @@ All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/a
 
 -->
 
-# OpenIndiana Handbook - Getting Started
+# Hipster Handbook - Getting Started with OpenIndiana
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
@@ -35,7 +35,7 @@ This collection of documents is aimed at providing a comprehensive source of gui
 While our aim is to address as many facets of OpenIndiana use and administration as possible, some topics are simply too complex and beyond the scope of an introductory end user handbook.
 In such cases external sources of information will be provided in the form of references to other web sites, man pages, or printed books.
 
-## OpenIndiana software releases
+## Hipster Software Releases
 
 <!--
 
@@ -74,7 +74,7 @@ While every package is tested to ensure stability, caution is nevertheless warra
 </div>
 
 
-## System requirements
+## System Requirements
 
 <!--
 
@@ -101,7 +101,7 @@ As the FAQ evolves, try to keep this section in sync.
 </div>
 
 
-## Exploring OpenIndiana
+## Exploring OpenIndiana Hipster
 
 There are several ways in which you can explore OpenIndiana without having to perform a bare metal install.
 
@@ -197,7 +197,7 @@ vagrant destroy
 ```
 
 
-## Preparation for installing OpenIndiana
+## Preparing to Install Hipster
 
 Prior to installing OpenIndiana:
 
@@ -295,7 +295,7 @@ OI-hipster-gui-20161030.iso: OK
 ```
 
 
-## Creating a bootable OpenIndiana DVD
+## Creating a Hipster DVD
 
 
 ### BSD/illumos/Solaris
@@ -474,7 +474,7 @@ From within Windows Explorer:
 </div>
 
 
-## Creating a bootable OpenIndiana USB flash drive
+## Creating a Hipster USB Drive
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
@@ -660,7 +660,7 @@ To resolve this issue, be sure to select the `*.*` (all files) option from the f
 The [OpenSolaris Live USB Creator](http://devzone.sites.pid0.org/OpenSolaris/opensolaris-liveusb-creator) is a small stand alone GUI utility suitable for creating an OpenIndiana bootable USB flash drive.
 
 
-## Booting OpenIndiana installer media
+## Booting the Hipster Installer
 
 Insert the bootable media (DVD or USB flash drive) and boot (start/restart) your computer.
 When you see the OpenIndiana boot menu, select a boot entry, and press the enter key to start OpenIndiana on your computer.
@@ -1482,7 +1482,7 @@ When booting from the text based installer, you are presented with the following
 The procedure for installing from the text based installer follows the same process as the previously described [Install OpenIndiana using the Text Installer](./getting-started/#install-openindiana-using-the-text-installer)
 
 
-## Troubleshooting installations
+## Troubleshooting Installations
 
 * If you do not see a menu after booting your computer with the DVD or USB device, and instead see some text and a `grub>` prompt, there may be an error in your copy of the installer, or it was created incorrectly.
 * If you see a `login:` prompt after selecting your keyboard and language and no desktop appears after several seconds, there may be a problem with the drivers for your graphics hardware.
@@ -1491,7 +1491,7 @@ The procedure for installing from the text based installer follows the same proc
     * If possible, also include the contents of the file `/var/log/Xorg.0.log`.
 
 
-## Post installation steps
+## Post Installation Steps
 
 ### Resetting the root password
 
@@ -2157,7 +2157,7 @@ Therefore, use 3rd party repositories and 3rd party package tools at your own ri
 </div>
 
 
-## Managing boot environments
+## Managing Boot Environments
 
 A boot environment is a bootable instance of an OpenIndiana operating system image plus any other application software packages installed into that image.
 You can maintain multiple boot environments on your system, and each boot environment could have different software versions installed.
@@ -2283,7 +2283,7 @@ The beadm command impacts the non-global zones in your boot environments as foll
 | `beadm rename` | When you rename a boot environment, that change does not impact the names of the zones or the names of the datasets that are used for those zones in that boot environment. The change does not impact the relationships between the zones and their related boot environments.
 
 
-## The X-Window system
+## The X-Window System
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **DOC TEAM NOTE:**
 <div class="well">
@@ -2318,7 +2318,7 @@ Write about:
 </div>
 
 
-## Device drivers
+## Device Drivers
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **DOC TEAM NOTE:**
 <div class="well">

--- a/docs/handbook/network-communications.md
+++ b/docs/handbook/network-communications.md
@@ -17,7 +17,7 @@ All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/a
 
 -->
 
-# OpenIndiana Handbook - Network Communications
+# Hipster Handbook - Network Communications
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
@@ -65,7 +65,7 @@ All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/a
 < Place holder for content >
 
 
-## Using OpenIndiana as a NAS
+## Hipster as a NAS
 
 OpenIndiana provides several ways to share data with network clients.
 
@@ -97,7 +97,7 @@ Also have a look at the [OpenSolaris CIFS Administration Guide](https://docs.ora
 </div>
 
 
-### Configuring OpenIndiana as a CIFS server (workgroup)
+### Hipster as a CIFS server (workgroup)
 
 < Placeholder for introduction content >
 
@@ -186,12 +186,12 @@ You can create additional CIFS datasets using the following 4 commands.
 * `sharemgr show -vp`
 
 
-### Configuring OpenIndiana as a CIFS server (domain)
+### Hipster as a CIFS server (domain)
 
 < Placeholder for introduction content >
 
 
-### Configuring OpenIndiana as a SAMBA server
+### Hipster as a SAMBA server
 
 < Place holder for content >
 
@@ -225,42 +225,42 @@ You can create additional CIFS datasets using the following 4 commands.
 < Place holder for content >
 
 
-### Configuring OpenIndiana as an NFS server
+### Hipster as an NFS server
 
 < Place holder for content >
 
 
-## Configuring OpenIndiana as an NIS server
+## Hipster as an NIS server
 
 < Place holder for content >
 
 
-## Configuring OpenIndiana as an LDAP server
+## Hipster as an LDAP server
 
 < Place holder for content >
 
 
-## Configuring OpenIndiana as a DHCP server
+## Hipster as a DHCP server
 
 < Place holder for content >
 
 
-## Configuring OpenIndiana as an FTP server
+## Hipster as an FTP server
 
 < Place holder for content >
 
 
-## Configuring OpenIndiana as a DNS server
+## Hipster as a DNS server
 
 < Place holder for content >
 
 
-## Configuring OpenIndiana as a NTP server
+## Hipster as a NTP server
 
 < Place holder for content >
 
 
-## Configuring OpenIndiana as a INETD server
+## Hipster as a INETD server
 
 < Place holder for content >
 

--- a/docs/handbook/systems-administration.md
+++ b/docs/handbook/systems-administration.md
@@ -17,7 +17,7 @@ All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/a
 
 -->
 
-# OpenIndiana Handbook - System Administration
+# Hipster Handbook - System Administration
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">

--- a/docs/handbook/systems-administration.md
+++ b/docs/handbook/systems-administration.md
@@ -46,7 +46,31 @@ All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/a
 
 ### Service management (SMF)
 
-< place holder >
+<i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **DOC TEAM NOTE:**
+<div class="well">
+ITEMS TO WRITE ABOUT:
+
+Start a service
+
+`svcadm enable <service name>`
+
+Start service along with it's dependencies
+
+`svcadm enable -r <service name>`
+
+Start a service temporarily (won't survive a reboot)
+
+`svcadm enable -t <service name>`
+
+Check service dependencies
+
+`svcs -d <service name >`
+
+Check status of services
+
+`svcs -vx`
+
+</div>
 
 
 ### Systems logging and monitoring

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,9 @@
 <div class="jumbotron">
   <img src = "Openindiana.png">
   <h1>Welcome to OpenIndiana Docs!</h1>
-  </br>
+  <br>
+  <h2>Home of the <b>Hipster Handbook</b></h2>
+  <br>
   <p>This site contains <b>DRAFT</b> documentation which may contain errors!</p>
   <p>Please help us improve and expand this site. See the <b>Contrib</b> section for more details about joining the OpenIndiana Documentation Team.</p>
 </div>


### PR DESCRIPTION
Shortened section titles (makes for a cleaner navigation menu).
Substituted the word "Hipster" for "OpenIndiana" in many different places.
Added a few SMF commands, etc.