### PR TITLE
update Makefile target env-check for userland.md

### DIFF
--- a/docs/dev/userland.md
+++ b/docs/dev/userland.md
@@ -43,7 +43,7 @@ git remote -v
 
 ```bash
 gmake setup
-gmake check-environment
+gmake env-check
 ```
 
 ### Every time you add or modify a component, create a new branch:


### PR DESCRIPTION
The [Quick start for oi-userland](http://docs.openindiana.org/dev/userland/) document has a step that recommends running an invalid Makefile target, check-environment.  I believe the correct target is env-check.

This change updates the doc to use the env-check target.