### PR TITLE
Fix error reporting pandoc not installed from makepdf.sh

### DIFF
--- a/makepdf.sh
+++ b/makepdf.sh
@@ -117,7 +117,7 @@ main ()
 
 
         # Required packages ok?
-        type pandoca >/dev/null 2>&1 || {
+        type pandoc >/dev/null 2>&1 || {
                 echo >&2 "ERROR: require package pandoc, please install pandoc."
                 exit 1; }
 


### PR DESCRIPTION
Although pandoc was installed, a typo caused this error always to
appear.

Silly error causing this script never to work!

Example:
    makepdf.sh -f ./docs/handbook/systems-administration.md