### PR TITLE
Fix typo in the link to docs.openindiana.org 

### DIFF
--- a/docs/release-notes/2019.10-release-notes.md
+++ b/docs/release-notes/2019.10-release-notes.md
@@ -213,7 +213,7 @@ Some of the more interesting changes include:
 
 ## Other activities
 
-A lot of work was done to update documentation from [outdated wiki](https://wiki.openindiana.org) and move it to new [docs site](https://docs.openinidana.org) and [oi-userland docs](https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/doc).
+A lot of work was done to update documentation from [outdated wiki](https://wiki.openindiana.org) and move it to new [docs site](https://docs.openindiana.org) and [oi-userland docs](https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/doc).
 
 ## Contributors
 


### PR DESCRIPTION
Link to https://docs.openindiana.org in the Other Activities section had a typo