### PR TITLE
Travis CI, bump to Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: '3.4'
+python: '3.5'
 install:
   - pip install -r requirements.txt
   - gem install mdl -v 0.4.0


### PR DESCRIPTION
It seems that pyYAML does not support Python 3.4, which got out of support, anymore:
```
...
Collecting PyYAML>=3.10 (from mkdocs==1.0.4->-r requirements.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/3d/d9/ea9816aea31beeadccd03f1f8b625ecf8f645bd66744484d162d84803ce5/PyYAML-5.3.tar.gz (268kB)
PyYAML requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*' but the running Python is 3.4.8
The command "pip install -r requirements.txt" failed and exited with 1 during .
```

See https://travis-ci.org/OpenIndiana/oi-docs/builds/636001956?utm_source=github_status&utm_medium=notification.