### PR TITLE
set userland as primary publisher

### DIFF
--- a/docs/dev/graphics-stack.md
+++ b/docs/dev/graphics-stack.md
@@ -81,7 +81,8 @@ The drivers series 340.xx, 390.xx, and 490.xx are currently part of oi-userland,
 
 The 390.xx drivers are current default.
 
-Note on switching driver versions 
+Note on switching driver versions
+
 ```
 # beadm create nvidia-460
 # beadm mount nvidia-460 /tmp/nvidia-460

--- a/docs/dev/userland.md
+++ b/docs/dev/userland.md
@@ -143,6 +143,12 @@ pfexec pkg set-publisher -g file://$HOME/oi-userland/i386/repo userland
 pfexec pkg set-publisher --non-sticky openindiana.org
 ```
 
+#### Setting the local repository as primary publisher
+
+```bash
+pfexec pkg set-publisher --search-first userland
+```
+
 #### Optional: Running a local pkg server for installation on other zones/hosts
 
 If you would like to use your oi-userland repository on other zones or hosts, you can run a pkg server:


### PR DESCRIPTION
Without `set-publisher --search-first` there tends to be conflict when installing local packages - higher ranker publisher openindiana.org tends to be chosen and the system doesn't install what was build locally. 