### PR TITLE
Fix makepdf.sh and replace HTML formatting with markdown equivalent

### DIFF
--- a/docs/community-hcl/components.md
+++ b/docs/community-hcl/components.md
@@ -144,7 +144,7 @@ These soundcards are compatible and 'known to work' with OpenIndiana.
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
-For a number of NICs, which are not currently supported "out of the box" by the illumos kernel or OpenIndiana distribution, over 30 open-sourced drivers covering many more chipsets and NIC models are available as part of the separate "Free NIC drivers for OpenSolaris" project by Masayuki Murayama and generally do just work on OpenIndiana (binaries are available as part of the source code tarballs, but you're encouraged to recompile them with GLDv3 Makefile's on OpenIndiana, see details on <a href="http://freenicdrivers.la.coocan.jp/">the project's web page</a>).
+For a number of NICs, which are not currently supported "out of the box" by the illumos kernel or OpenIndiana distribution, over 30 open-sourced drivers covering many more chipsets and NIC models are available as part of the separate "Free NIC drivers for OpenSolaris" project by Masayuki Murayama and generally do just work on OpenIndiana (binaries are available as part of the source code tarballs, but you're encouraged to recompile them with GLDv3 Makefile's on OpenIndiana, see details on [the project's web page](http://freenicdrivers.la.coocan.jp/)).
 </div>
 
 NIC                                                  | Works (yes/no)  | Notes                  | Driver | Contributor
@@ -212,7 +212,7 @@ Intel GMA 950                            | yes                    |             
 Intel HD Graphics 520                    | yes                    | HP 15t Laptop (Part#: V1Z72AV_1). Tested at 1920x1080. | i915 |
 Intel HD Graphics 530                    | no                     | HP ZBook Studio G3. Crashes, system has both discrete graphics and Intel graphics | |
 Intel HD Graphics 2000                   | yes                    | ThinkCentre M91p. Working, tested from 1024x768 to 1920x1080, GPU hangs and wrong screen adjustment. | i915 |
-Intel HD Graphics 3000                   | yes                    | Lenovo ThinkPad X220. Has a <a href="https://www.illumos.org/issues/8757">glitch</a> on embedded display (<a href="https://www.illumos.org/issues/8049#note-7">workaround</a>). Display Port & VGA D-Sub work. | i915 | Michal Nowak
+Intel HD Graphics 3000                   | yes                    | Lenovo ThinkPad X220. Has a [glitch](https://www.illumos.org/issues/8757) on embedded display ([workaround](https://www.illumos.org/issues/8049#note-7)). Display Port & VGA D-Sub work. | i915 | Michal Nowak
 Intel HD Graphics 4000                   | yes                    |                                          | i915   | Aurélien Larcher
 Intel HD Graphics 4600                   | yes                    | Dell Precision M2800. Tested at 1920x1080. | i915 |
 Intel Iris Pro Graphics                  | yes                    |                                          | i915   | Martin Bochnig
@@ -232,7 +232,7 @@ NVIDIA GeForce GTX 765M                  | yes                    | PCI-ID: 10de
 NVIDIA GeForce GTX 780M                  | yes                    | PCI-ID: 10de:119f, Nvidia 340.107        | nvidia | Jim Gorzelany
 NVIDIA GeForce GTX 880M                  | yes                    | PCI-ID: 10de:1198 - Tested on Asus ROG G750JZ with hipster-070114 ISO | nvidia | Mike Kelley
 NVIDIA GeForce TITAN X                   | yes                    | Nvidia 340.107                           | nvidia | John Hahnua
-NVIDIA Titan Xp                          | yes                    | <a href="http://http.download.nvidia.com/solaris/390.67/NVIDIA-Solaris-x86-390.67.run">Nvidia 390.67</a> | nvidia | Ken Mays
+NVIDIA Titan Xp                          | yes                    | [Nvidia 390.67](http://http.download.nvidia.com/solaris/390.67/NVIDIA-Solaris-x86-390.67.run) | nvidia | Ken Mays
 AMD/ATI Radeon HD 4770 [RV740] PCI-e     | vgatext                | PCI-ID: 1002:94b3 - DVI ports work (but trying to rotate broke X) - overall resolution limited to 2560x2560 | vgatext | Ancoron Luciferis
 AMD/ATI Radeon HD 5770 PCI-e             | vgatext                | PCI-ID: 1002:68b8 - DVI ports work (but trying to rotate broke X) - overall resolution limited to 2560x2560 | vgatext | Ancoron Luciferis
 ASUS EAH4350 (ATI RV710 - Radeon HD 4350)| vgatext                | Have only tried the DVI port             | vgatext | Philip Robar
@@ -314,7 +314,7 @@ Supermicro   | X9DRD-7LN4F-JBOD                   | mga, ahci   |               
 Supermicro   | X10SLM-F                           | npe, e1000g, vgatext, igb, pcieb | igb and e1000g compiled from illumos git source, for SOL console sol1 use ttyb | Carsten Grzemba
 Tyan         | Tomcat K8E (S2865 AG2NRF)          |             |                                                      | Ken Gunderson
 Tyan         | S2927-E                            |             | Tyan Thunder n3600B S2927-E (S2927G2NR-E) motherboard| Ken Mays
-Tyan         | S5510GM3NR                         |             | Test System: Xeon LGA1155 C204 with Intel Core i3 2100.<ul><li>IPMI: SUPPORTED with BIOS V2.01c or bug <a href="https://www.illumos.org/issues/2560">#2560</a> fix.</li></ul> | Gary Mills
+Tyan         | S5510GM3NR                         |             | Test System: Xeon LGA1155 C204 with Intel Core i3 2100.<ul><li>IPMI: SUPPORTED with BIOS V2.01c or bug [#2560](https://www.illumos.org/issues/2560) fix.</li></ul> | Gary Mills
 Zotac        | G43ITX-A-E                         |             | Intel Q8400, 4 GB RAM, onboard Intel X4500 VGA (see note below).<br/>Running with 8 HDDs:<br><ul><li>5 using Intel ICH10R internal SATA (AHCI)</li><li>1 using Intel ICH10R eSATA (AHCI)</li><li>2 using add-on ASMedia ASM1061 PCI-E X1 SATA card (Device supported and detected by OI but HDD not detected. Possibly due to other unrelated issues. Still testing.)</li></ul>Note: The Intel X4500 VGA adapter will throw up some errors pertaining to "regiter error" and "vga init error" either during setup or boot. However, it will still work fine and OI will install / boot without problems. Unsupported driver issues? | Dedy Johan
 
 ## Peripheral Devices

--- a/docs/contrib/markdown.md
+++ b/docs/contrib/markdown.md
@@ -222,11 +222,9 @@ Specify the relative path to the image, just like an internal URL.
 ```
 
 **Rendered HTML** <i class="fa fa-html5" aria-hidden="true"></i>
-<div class="well">
 
 ![openindiana logo](../Openindiana.png)
 
-</div>
 
 
 ### Block quotes

--- a/docs/dev/legacy-consolidations.md
+++ b/docs/dev/legacy-consolidations.md
@@ -49,13 +49,13 @@ This complex Release Engineering has been deprecated in favour of the unified bu
  Consolidation | Oracle Solaris link                   | Original Openindiana HG link                             | Status                                  | OpenIndiana Hipster link | Build instructions
 -------------- |---------------------------------------| -------------------------------------------------------- | ----------------------------------------| ------------------------ | ------------------
  onnv-gate     | N/A (closed source) | N/A  | Replaced by illumos-gate |  N/A | N/A
- illumos-gate  | N/A | <https://github.com/OpenIndiana/illumos-gate/>  | Integrated in <a href="https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/components/openindiana/illumos-gate">oi-userland</a> | <https://github.com/illumos/illumos-gate/> | <https://illumos.org/docs/developers/build/>
- oi-build      | <https://github.com/Oracle/solaris-userland/> | <https://hg.openindiana.org/sustaining/oi_151a/oi-build/> | Superceded by <a href="https://github.com/OpenIndiana/oi-userland/">oi-userland</a> | <https://github.com/OpenIndiana/oi-userland> | [Building oi-build](#building-oi-build)
- IPS/pkg       | <https://github.com/Oracle/solaris-ips/> | <https://hg.openindiana.org/sustaining/oi_151a/pkg-gate/>  | Integrated in <a href="https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/components/openindiana/pkg">oi-userland</a> | <https://github.com/OpenIndiana/pkg5/> | [Building IPS/pkg](#building-ipspkg)
- SFW           | N/A (merged into <a href="http://github.com/Oracle/solaris-userland/">solaris-userland</a>) | <https://hg.openindiana.org/sustaining/oi_151a/sfw-gate/> | Merged into <a href="https://github.com/OpenIndiana/oi-userland/">oi-userland</a>| N/A | [Building SFW](#building-sfw)
- XNV           | <https://github.com/Oracle/solaris-xorg/> (merged into <a href="https://github.com/oracle/solaris-userland/tree/master/components/x11">solaris-userland</a>)| <https://hg.openindiana.org/sustaining/oi_151a/xnv/>|  Merged into <a href="https://github.com/OpenIndiana/oi-userland/">oi-userland</a> | N/A | [Building XNV](#building-xnv)
- JDS           | N/A  (merged into <a href="https://github.com/Oracle/solaris-userland/">solaris-userland</a>) | <https://hg.openindiana.org/sustaining/oi_151a/spec-files/> | Merged into <a href="https://github.com/OpenIndiana/oi-userland/">oi-userland</a>| N/A | [Building JDS](#building-jds)
- Caiman (slim_source) | N/A | <https://hg.openindiana.org/sustaining/oi_151a/slim_source/> | Integrated in <a href="https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/components/openindiana/slim_source">oi-userland</a> | <https://github.com/OpenIndiana/slim_source/> | [Building slim_source](#building-slim_source)
+ illumos-gate  | N/A | <https://github.com/OpenIndiana/illumos-gate/>  | Integrated in [oi-userland](https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/components/openindiana/illumos-gate) | <https://github.com/illumos/illumos-gate/> | <https://illumos.org/docs/developers/build/>
+ oi-build      | <https://github.com/Oracle/solaris-userland/> | <https://hg.openindiana.org/sustaining/oi_151a/oi-build/> | Superceded by [oi-userland](https://github.com/OpenIndiana/oi-userland/) | <https://github.com/OpenIndiana/oi-userland> | [Building oi-build](#building-oi-build)
+ IPS/pkg       | <https://github.com/Oracle/solaris-ips/> | <https://hg.openindiana.org/sustaining/oi_151a/pkg-gate/>  | Integrated in [oi-userland](https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/components/openindiana/pkg) | <https://github.com/OpenIndiana/pkg5/> | [Building IPS/pkg](#building-ipspkg)
+ SFW           | N/A (merged into [solaris-userland](http://github.com/Oracle/solaris-userland/)) | <https://hg.openindiana.org/sustaining/oi_151a/sfw-gate/> | Merged into [oi-userland](https://github.com/OpenIndiana/oi-userland/)| N/A | [Building SFW](#building-sfw)
+ XNV           | <https://github.com/Oracle/solaris-xorg/> (merged into [solaris-userland](https://github.com/oracle/solaris-userland/tree/master/components/x11))| <https://hg.openindiana.org/sustaining/oi_151a/xnv/>|  Merged into [oi-userland](https://github.com/OpenIndiana/oi-userland/) | N/A | [Building XNV](#building-xnv)
+ JDS           | N/A  (merged into [solaris-userland](https://github.com/Oracle/solaris-userland/)) | <https://hg.openindiana.org/sustaining/oi_151a/spec-files/> | Merged into [oi-userland](https://github.com/OpenIndiana/oi-userland/)| N/A | [Building JDS](#building-jds)
+ Caiman (slim_source) | N/A | <https://hg.openindiana.org/sustaining/oi_151a/slim_source/> | Integrated in [oi-userland](https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/components/openindiana/slim_source) | <https://github.com/OpenIndiana/slim_source/> | [Building slim_source](#building-slim_source)
  vpanels       | N/A (dropped) | N/A | Dropped | N/A | N/A
  sunpro/devpro | N/A (closed source) | N/A | libm and make were integrated to illumos-gate, other parts are delivered in binary form (including library/medialib, system/library/c++/sunpro, developer/macro/cpp, system/library/mtsk) | N/A | N/A
  xvm           | N/A (dropped) | N/A | Dropped | N/A | N/A
@@ -72,14 +72,15 @@ Note, these instructions were not tested on modern OpenIndiana versions and pres
 
 ## Building oi-build
 
+<i class="fa fa-exclamation-triangle fa-lg" aria-hidden="true"></i> **CAUTION:**
 <div class="well">
-<font color="red">oi-build is a legacy consolidation which was superceded with oi-userland !!!</font>
-For  building oi-userland see <a href="../userland/">Building with oi-userland</a>
+**oi-build is a legacy consolidation which was superceded with oi-userland !!!**
+For  building oi-userland see [Building with oi-userland](../userland/)
 </div>
 
 Following instructions describe building oi-build on legacy OpenIndiana /dev distribution.
 
-<b>oi-build</b> is OpenIndiana's primary build framework for post-oi_151 development. It is set to replace all existing consolidations, vastly simplifying how we build the operating system.
+**oi-build** is OpenIndiana's primary build framework for post-oi_151 development. It is set to replace all existing consolidations, vastly simplifying how we build the operating system.
 
 oi-build is also tied into our continuous integration platform. When an update is committed to the oi-build mercurial repository, an automated build is kicked off. This will then automatically publish the built package to the /experimental repo, or generate an email alert if the build failed (to be completed).
 
@@ -91,22 +92,21 @@ Inside oi-build is a directory called `components`, under which lives a director
 
 The `Makefile` essentially contains a "build recipe". To build a piece of software, you simply `cd` into the directory of the software, and type `make TARGET`, where `TARGET` can be one of:
 
-* <b>prep</b> : Download, extract and patch the software archive
-* <b>build</b> : Build the software
-* <b>install</b> : Install the software into the prototype directory
-* <b>sample-manifest</b> : Create a sample manifest file in the build directory
-* <b>publish</b> : Publish the software to the local userland IPS repo
+* **prep** : Download, extract and patch the software archive
+* **build** : Build the software
+* **install** : Install the software into the prototype directory
+* **sample-manifest** : Create a sample manifest file in the build directory
+* **publish** : Publish the software to the local userland IPS repo
 
 For more details about writing Makefiles for userland, see userland Makefile targets and variables
 
+<i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
-Before adding new packages to illumos-userland...
+Before adding new packages to illumos-userland... Before considering adding a new package to oi-build, please check first whether someone else is working on the package by checking the issue tracker.
 
-Before considering adding a new package to oi-build, please check first whether someone else is working on the package by checking the issue tracker.
-<ul>
-<li>If you don't find anyone already working on a port, please register your effort by opening an issue.</li>
-<li>If you wish to update an existing port, look at the log for the component Makefile ("hg log Makefile") and make sure you either contact the person who last updated the Makefile or include them on notifications for the issue by ticking their name.</li>
-</ul>
+* If you don't find anyone already working on a port, please register your effort by opening an issue.
+* If you wish to update an existing port, look at the log for the component Makefile ("hg log Makefile") and make sure you either contact the person who last updated the Makefile or include them on notifications for the issue by ticking their name.
+
 
 This will ensure efforts aren't duplicated and help to ensure sanity and comity amongst project members.
 </div>
@@ -214,7 +214,7 @@ gmake setup
 gmake setup COMPILER=gcc
 ```
 
-<b>Important:</b> Checking your environment
+**Important:** Checking your environment
 
 Make the check-environment target to check your environment is set up correctly:
 
@@ -286,8 +286,9 @@ hg commit -u 'Contributor Name <contributor.name@fake.net>'
 
 ## Building IPS/pkg
 
+<i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
-For building IPS delivered with modern OpenIndiana, use <a href="https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/components/openindiana/pkg">openindiana/pkg</a> oi-userland component.
+For building IPS delivered with modern OpenIndiana, use [openindiana/pkg](https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/components/openindiana/pkg) oi-userland component.
 </div>
 
 Following instructions describe building pkg on legacy OpenIndiana /dev distribution.
@@ -616,8 +617,9 @@ SVR4 packages will be placed into ${HOME}/packages.
 
 ## Building slim_source
 
+<i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
-For building slim_source used in modern OpenIndiana, use <a href="https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/components/openindiana/slim_source">openindiana/slim_source</a> oi-userland component.
+For building slim_source used in modern OpenIndiana, use [openindiana/slim_source](https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/components/openindiana/slim_source") oi-userland component.
 </div>
 
 Following instructions describe building slim_source on legacy OpenIndiana /dev distribution.

--- a/docs/dev/userland.md
+++ b/docs/dev/userland.md
@@ -25,7 +25,7 @@ All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/a
 
 ## Using OpenIndiana's unified build system
 
-OpenIndiana Hipster's primary build framework is oi-userland. It's tied into OpenIndiana <a href="https://hipster.openindiana.org/jenkins">continuous integration platform</a>.
+OpenIndiana Hipster's primary build framework is oi-userland. It's tied into OpenIndiana [continuous integration platform](https://hipster.openindiana.org/jenkins).
 
 When an update is committed to the oi-userland git repository:
 
@@ -35,7 +35,7 @@ When an update is committed to the oi-userland git repository:
 
 ### Overview of oi-userland
 
-Originally oi-userland is a fork of Oracle's <a href="https://github.com/oracle/solaris-userland/">userland-gate</a> which evolved in an independent way. The layout is very similar.
+Originally oi-userland is a fork of Oracle's [userland-gate](https://github.com/oracle/solaris-userland/) which evolved in an independent way. The layout is very similar.
 
 Inside oi-userland is a directory called "components", under which directories for software package category groups live.
 Inside each of these package group directories are typically directories for all software packages belonging to the category.
@@ -70,12 +70,13 @@ To build a component you simply cd into the directory of the software, and type 
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
-<p><b>Before adding new packages to oi-userland...</b></p>
-Before considering adding a new package to oi-userland, please check first whether someone else is working on the package by checking the issue tracker, mailing <a href="mailto:oi-dev@openindiana.org">oi-dev@openindiana.org</a> or asking on the IRC (#oi-dev at irc.freenode.net)
-<ul>
-<li>If you don't find anyone already working on a port, please register your effort by opening an issue.</li>
-<li>If you wish to update an existing port, look at the log for the component Makefile ("git log Makefile") and make sure you either contact the person who last updated the Makefile or include them on notifications for the issue by ticking their name.</li>
-</ul>
+**Before adding new packages to oi-userland...**
+
+Before considering adding a new package to oi-userland, please check first whether someone else is working on the package by checking the issue tracker, mailing [oi-dev@openindiana.org](mailto:oi-dev@openindiana.org) or asking on the IRC (#oi-dev at irc.freenode.net)
+
+* If you don't find anyone already working on a port, please register your effort by opening an issue.
+* If you wish to update an existing port, look at the log for the component Makefile ("git log Makefile") and make sure you either contact the person who last updated the Makefile or include them on notifications for the issue by ticking their name.
+
 This will ensure efforts aren't duplicated and help to ensure sanity and comity amongst project members.
 </div>
 
@@ -232,12 +233,12 @@ Here
 | COMPONENT_CLASSIFICATION | System/Multimedia Libraries | This entry should be in the [OpenSolaris IPS Classification 2008](https://github.com/OpenIndiana/pkg5/blob/oi/doc/dev-guide/appendix-a.txt) |
 | COMPONENT_PROJECT_URL | http://www.ijg.org/ | Upstream project website |
 | COMPONENT_SUMMARY | libjpeg - Independent JPEG Group library version 6b | A short description (one-liner) |
-| COMPONENT_SRC | jpeg-$(LIBJPEG_API_VERSION) | The name of source after unpacking the archive |
-| COMPONENT_ARCHIVE | $(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz | The software archive |
+| COMPONENT_SRC | `jpeg-$(LIBJPEG_API_VERSION)` | The name of source after unpacking the archive |
+| COMPONENT_ARCHIVE | `$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz` | The software archive |
 | COMPONENT_ARCHIVE_HASH | sha256:75c3ec241e9996504fe02a9ed4d12f16b74ade713972f3db9e65ce95cd27e35d | The SHA256 checksum of software archive |
-| COMPONENT_ARCHIVE_URL | http://www.ijg.org/files/jpegsrc.v$(LIBJPEG_API_VERSION).tar.gz | The URI to get the COMPONENT_ARCHIVE |
+| COMPONENT_ARCHIVE_URL | `http://www.ijg.org/files/jpegsrc.v$(LIBJPEG_API_VERSION).tar.gz` | The URI to get the COMPONENT_ARCHIVE |
 | COMPONENT_LICENSE | IJG,GPLv2.0 | A comma separated list of licenses |
-| COMPONENT_LICENSE_FILE | $(COMPONENT_NAME).license | The file with license text |
+| COMPONENT_LICENSE_FILE | `$(COMPONENT_NAME).license` | The file with license text |
 
 Components are usually based on one of the following Makefiles depending on build system used by packaged software (look in the `make-rules` directory for more makefiles):
 

--- a/docs/handbook/appendix.md
+++ b/docs/handbook/appendix.md
@@ -23,9 +23,12 @@ All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/a
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
-<p>This is a <b>DRAFT</b> document which may contain errors!</p>
-<p>Help us improve and expand this site.</p>
-<p>Please see the <b>Contrib</b> section for more details about joining the OpenIndiana Documentation Team.</p>
+This is a **DRAFT** document which may contain errors!
+
+Help us improve and expand this site.
+
+Please see the **Contrib** section for more details about joining the OpenIndiana Documentation Team.
+
 </div>
 
 < place holder for introduction content >

--- a/docs/handbook/common-tasks.md
+++ b/docs/handbook/common-tasks.md
@@ -23,9 +23,12 @@ All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/a
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
-<p>This is a <b>DRAFT</b> document which may contain errors!</p>
-<p>Help us improve and expand this site.</p>
-<p>Please see the <b>Contrib</b> section for more details about joining the OpenIndiana Documentation Team.</p>
+This is a **DRAFT** document which may contain errors!
+
+Help us improve and expand this site.
+
+Please see the **Contrib** section for more details about joining the OpenIndiana Documentation Team.
+
 </div>
 
 < place holder for introduction content >

--- a/docs/handbook/community.md
+++ b/docs/handbook/community.md
@@ -26,12 +26,13 @@ All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/a
 
 Contributed by OpenIndiana community member Franklin Ronald, this article details the steps required for the installation of Oracle Database 11R2 on OpenIndiana Hipster.
 
-Link to PDF Document: <a href= "../pdf/HowToInstallOracleDB.pdf" target="_blank">How to Install Oracle Database 11R2 on OpenIndiana Hipster</a>
+Link to PDF Document: [How to Install Oracle Database 11R2 on OpenIndiana Hipster](../pdf/HowToInstallOracleDB.pdf)
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
-<p>It is not recommended to run Oracle Database on OpenIndiana in a production environment. Oracle has a restricted list of supported operating systems and unfortunately OpenIndiana is not in it. The purpose of this article is to install the Oracle Database for use in a development environment.</p>
-<p>Unfortunately, it is not possible to run Oracle Database version 12 and above on OpenIndiana.</p>
+It is not recommended to run Oracle Database on OpenIndiana in a production environment. Oracle has a restricted list of supported operating systems and unfortunately OpenIndiana is not in it. The purpose of this article is to install the Oracle Database for use in a development environment.
+
+Unfortunately, it is not possible to run Oracle Database version 12 and above on OpenIndiana.
 </div>
 
 ## How to Install Sun Ray Software on OpenIndiana Hipster
@@ -42,15 +43,16 @@ Link to document: [Sun Ray Software on OpenIndiana Hipster](../handbook/sunray.m
 
 ## How to Install the TeX Live Typesetting Software on OpenIndiana Hipster
 
-Link to TeXLive Document: <a href= "texlive/index.html" target="_blank">OpenIndiana Hipster Notes for TeX Live Users</a>
+Link to TeXLive Document: [OpenIndiana Hipster Notes for TeX Live Users](texlive/index.html)
 
 ## How to Install Squeak Smalltalk-80 on OpenIndiana Hipster
 
-Link to Squeak Document: <a href= "squeak/index.html" target="_blank">OpenIndiana Hipster Notes for Squeak Users</a>
+Link to Squeak Document: [OpenIndiana Hipster Notes for Squeak Users](squeak/index.html)
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **Call for Contributors:**
 <div class="well">
-<p>Help us improve and expand this page by offering your community written tutorials for publication on this site.</p>
-<p>Please see the <b>Contrib</b> section for more details. The docs team can be reached via email: <b>docs at openindiana.org.</b></p>
+Help us improve and expand this page by offering your community written tutorials for publication on this site.
+
+Please see the **Contrib** section for more details. The docs team can be reached via email: **docs at openindiana.org.**
 </div>
 

--- a/docs/handbook/community/squeak.md
+++ b/docs/handbook/community/squeak.md
@@ -14,17 +14,17 @@ Contributor(s): David Stes.
 
 -->
 
-<img src = "../../Openindiana.png">
+<img src = "../../../Openindiana.png">
 
 # Hipster Handbook - Squeak, Cuis and Smalltalk-80
 
 The following notes document the steps to install Squeak and Cuis on OpenIndiana Hipster, and how to use these implementations of Smalltalk-80.
 
-Squeak consists of a VM (virtual machine) and Smalltalk images.  You can find Smalltalk images at <a href= "http://files.squeak.org" target="_blank">files.squeak.org</a> or at <a href="http://cuis-smalltalk.org" target="_blank">cuis-smalltalk.org</a>.
+Squeak consists of a VM (virtual machine) and Smalltalk images.  You can find Smalltalk images at [files.squeak.org](http://files.squeak.org) or at [cuis-smalltalk.org](http://cuis-smalltalk.org).
 
 Cuis and Squeak both use the Squeak VM, but they offer different Smalltalk images.  The Squeak images have traditional MVC (Model, View, Controller) and Morphic graphical user interface classes.   Cuis has Morphic-3, which is an enhanced set of Morphic classes.
 
-See the <a href="http://www.squeak.org" target="_blank">Squeak website</a> for more and general information on Squeak, specifically the documentation section.  See <a href="http://cuis-smalltalk.org" target="_blank">cuis-smalltalk.org</a> for more info Cuis.  Also see the Squeak Wiki : <a href= "http://wiki.squeak.org" target="_blank">Squeak Wiki</a>
+See the [Squeak website](http://www.squeak.org) for more and general information on Squeak, specifically the documentation section.  See [cuis-smalltalk.org](http://cuis-smalltalk.org) for more info Cuis.  Also see the Squeak Wiki : [Squeak Wiki](http://wiki.squeak.org)
 
 ## Classic VM and OpenSmalltalk VM
 

--- a/docs/handbook/community/texlive.md
+++ b/docs/handbook/community/texlive.md
@@ -14,11 +14,11 @@ Contributor(s): David Stes.
 
 -->
 
-<img src = "../../Openindiana.png">
+<img src = "../../../Openindiana.png">
 
 # Hipster Handbook - TeX Live Typesetting Software
 
-The following notes document the steps to install <a href= "http://tug.org/texlive" target="_blank">TeX Live</a> on OpenIndiana Hipster and how to update it using the tlmgr TeX Live package management tool.
+The following notes document the steps to install [TeX Live](http://tug.org/texlive) on OpenIndiana Hipster and how to update it using the tlmgr TeX Live package management tool.
 
 ## TeX Live tlmgr Management Tool
 
@@ -28,9 +28,9 @@ The TeX Live Management Tool has both a command line interface and a GUI.  The G
 
 ## TeX Live Cross Platform Installer
 
-See the full TeX Live guide at <a href="http://tug.org/texlive/doc/texlive-en/texlive-en.html#installation" target="_blank">http://tug.org/texlive</a> for detailed information.
+See the full TeX Live guide at [http://tug.org/texlive](http://tug.org/texlive/doc/texlive-en/texlive-en.html#installation) for detailed information.
 
-Download the TeX Live Cross Platform Installer from <a href="http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz" target="_blank">http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz</a>.
+Download the TeX Live Cross Platform Installer from <http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz>.
 
 There is a script in this package, called install-tl.   The goal is to install TeX Live using the cross platform installer as follows :
 

--- a/docs/handbook/getting-started.md
+++ b/docs/handbook/getting-started.md
@@ -24,9 +24,11 @@ All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/a
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
 
-<p>This is a <b>DRAFT</b> document which may contain errors!</p>
-<p>Help us improve and expand this site.</p>
-<p>Please see the <b>Contrib</b> section for more details about joining the OpenIndiana Documentation Team.</p>
+This is a **DRAFT** document which may contain errors!
+
+Help us improve and expand this site.
+
+Please see the **Contrib** section for more details about joining the OpenIndiana Documentation Team.
 
 </div>
 
@@ -79,15 +81,11 @@ For a full list of links to the various installer images, visit the [OpenIndiana
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
 
-<ul>
-  <li>The legacy oi-dev-151x branch is no longer maintained.</li>
-  <li>While upgrades to Hipster are possible, it can only be performed by doing it in stages.</li>
-  <ul>
-    <li>First upgrade from oi-dev to Hipster-2015, and verify the system has been updated to the latest 2015.</li>
-    <li>Only then may you switch to the current Hipster repository and update again.</li>
-    <li><a href="https://wiki.openindiana.org/pages/viewpage.action?pageId=30802657">For more details, click here for upgrade instructions</a></li>
-  </ul>
-</ul>
+* The legacy oi-dev-151x branch is no longer maintained.
+* While upgrades to Hipster are possible, it can only be performed by doing it in stages.
+    * First upgrade from oi-dev to Hipster-2015, and verify the system has been updated to the latest 2015.
+    * Only then may you switch to the current Hipster repository and update again.
+    * [For more details, click here for upgrade instructions](https://wiki.openindiana.org/pages/viewpage.action?pageId=30802657)
 
 </div>
 
@@ -118,12 +116,10 @@ As the FAQ evolves, try to keep this section in sync.
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
 
-<ul>
-  <li>For the best performance (and to reduce the possibility of disk swapping), allocate 4GB RAM or more.</li>
-  <li>For desktops, ensure total system memory (RAM + swap) are at least 4GB or greater.</li>
-  <li>The default size of the OpenIndiana swap file is 50% of installed memory.</li>
-  <li>Minimum and maximum default swap allocations are 512MB and 32GB respectively.</li>
-</ul>
+* For the best performance (and to reduce the possibility of disk swapping), allocate 4GB RAM or more.
+* For desktops, ensure total system memory (RAM + swap) are at least 4GB or greater.
+* The default size of the OpenIndiana swap file is 50% of installed memory.
+* Minimum and maximum default swap allocations are 512MB and 32GB respectively.
 
 </div>
 
@@ -547,13 +543,13 @@ OpenIndiana Hipster does not yet support UEFI.
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
 
-* Header files are only required when writing a legacy image <b>AND</b> using the dd utility.
-    * Header files are <b>NOT</b> required when writing current images.
-    * For example: The Hipster 2016.10 release, does <b>NOT</b> require header files.
+* Header files are only required when writing a legacy image **AND** using the dd utility.
+    * Header files are **NOT** required when writing current images.
+    * For example: The Hipster 2016.10 release, does **NOT** require header files.
 
 </div>
 
-* Download the appropriate OpenIndiana <a href="http://dlc.openindiana.org/isos/archive/1G.header">1G</a> or <a href="http://dlc.openindiana.org/isos/archive/2G.header">2G</a> header file
+* Download the appropriate OpenIndiana [1G](http://dlc.openindiana.org/isos/archive/1G.header") or [2G](http://dlc.openindiana.org/isos/archive/2G.header) header file
     * There are 2 unique USB header files (1G and 2G).
     * Please ensure you have selected the correct file as the files are **NOT** interchangeable.
         * The 1G.header is only suitable for use with the text installer (Command line console).
@@ -724,7 +720,7 @@ See the notes below for optimizing OpenIndiana for several popular hypervisors.
 | --- | ---
 | Virtualbox | OS type = Solaris 11 64-bit
 | Vmware player | OS type = Solaris 11 64-bit
-| KVM | <ul><li>OS type = Sun OpenSolaris</li><li>Disk = SATA</li><li>Remove USB Tablet</li><li>NIC = e1000</li><li>sound = AC97</li><li>Processor = Copy host CPU configuration</li><li>Disable CPU feature _'xsave'_</li><li>Video = QXL (QXL driver not supported, but the extra video memory helps)</li><li>Display = VNC (Spice not supported)</li></ul>
+| KVM | OS type = Sun OpenSolaris <br>Disk = SATA <br>Remove USB Tablet <br>NIC = e1000 <br>sound = AC97 <br>Processor = Copy host CPU configuration <br>Disable CPU feature _'xsave'_ <br>Video = QXL (QXL driver not supported, but the extra video memory helps) <br>Display = VNC (Spice not supported)
 | Hyper-V | Select single CPU, generation 1 VM, and legacy NIC.
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
@@ -750,7 +746,7 @@ The new boot loader provides many new capabilities:
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
 
-The OpenIndiana installer will automatically boot option # <b>1. Boot Multi User</b> within 10 seconds.
+The OpenIndiana installer will automatically boot option # **1. Boot Multi User** within 10 seconds.
 
 * To pause the Autoboot timer, press the `Space` key.
 
@@ -926,9 +922,9 @@ Select the appropriate installer option by clicking the corresponding desktop in
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
 
-<b>New for the Hipster 2016.10 release</b>
+**New for the Hipster 2016.10 release**
 
-Selecting the <b><i>Install OpenIndiana using the Text Installer</i></b> desktop installer option provides new installation capabilities.
+Selecting the ***Install OpenIndiana using the Text Installer*** desktop installer option provides new installation capabilities.
 
 In addition to installing OpenIndiana to single disks, the following are now also supported:
 
@@ -1169,9 +1165,9 @@ After you have installed OpenIndiana, if you have another operating system insta
 Usually you can achieve the desired effect by chainloading partitions with other operating systems.
 To configure the illumos loader to show an additional entry for chainloading another loader, create a file in /boot/conf.d directory,
 containing the string
-<code>chain_disk="disk0:"</code>,
+`chain_disk="disk0:"`,
 where disk0 is the name of disk or partition to boot from.
-You can get the list of available disks from loader prompt using <code>lsdev</code> command.
+You can get the list of available disks from loader prompt using `lsdev` command.
 
 If you use GRUB2, you can configure it to show an entry for chainloading the illumos loader.
 Add the following to a file in the /etc/grub.d directory (usually the placeholder '40_custom' file can be used) of the Linux installation:
@@ -1184,9 +1180,9 @@ menuentry "Chainload OpenIndiana" {
 ```
 
 where hd0,2 is the location of the partition or disk containing the illumos loader.
-You can list detected disks/partitions from the GRUB prompt using the <code>ls</code> command.
-From Linux you can run <code>sudo fdisk -l</code> to list disks and partitions. The partition 'sda2' would map to 'hd0,2' in GRUB.
-After making changes you must run <code>sudo update-grub</code>,
+You can list detected disks/partitions from the GRUB prompt using the `ls` command.
+From Linux you can run `sudo fdisk -l` to list disks and partitions. The partition 'sda2' would map to 'hd0,2' in GRUB.
+After making changes you must run `sudo update-grub`,
 this updates the auto-generated GRUB configuration stored in /boot/grub/grub.cfg.
 </div>
 
@@ -1200,30 +1196,26 @@ Navigation within the installer is performed by pressing specifically designated
 
 The instructions for performing a text based install apply to the following installation scenarios:
 
-<ul>
-  <li> Launching the text based installer icon from the Live Media (GUI) desktop.</li>
-  <li> Beginning a text based installation by booting from the OpenIndiana text based installer.</li>
-</ul>
+* Launching the text based installer icon from the Live Media (GUI) desktop.
+* Beginning a text based installation by booting from the OpenIndiana text based installer.
 
 <br>
-<b>New for the 2016.10 release</b>
+**New for the 2016.10 release**
 
 Mirrors and RAIDZ are now supported install options!
 
-<ul>
-  <li>To install to a mirror, select 2 or more disks.</li>
-  <li>To install to RAIDZ, select 3 or more disks.</li>
-</ul>
+* To install to a mirror, select 2 or more disks.
+* To install to RAIDZ, select 3 or more disks.
 
 <br>
-<b>GUI Desktop may be added post-installation</b>
-<Ul>
- <li>To install MATE Desktop Environment</li>
- <pre>
- # pkg install mate_install
- # pkg uninstall mate_install
- # init 6
- </pre>
+**GUI Desktop may be added post-installation**
+
+* To install MATE Desktop Environment
+```
+pkg install mate_install
+pkg uninstall mate_install
+init 6
+```
 </div>
 
 <a name="welcome-screen"></a>
@@ -1389,7 +1381,7 @@ When ready, press the `F2` key to continue.
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
-This screen will be available only when the <b><i>Manually</i></b> configure network option has been selected.
+This screen will be available only when the ***Manually*** configure network option has been selected.
 
 * The values illustrated above are for example only, do not use them.
 * Substitute each field with correct values for your network.
@@ -1418,7 +1410,7 @@ When ready, press the `F2` key to continue.
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
-When selecting the <b><i>UTC/GMT</i></b> time zone region, only this screen will be presented.
+When selecting the ***UTC/GMT*** time zone region, only this screen will be presented.
 </div>
 
 ![Time Zone - Location](./images/text_install/text_install_11.png)
@@ -1600,7 +1592,7 @@ Further it's considered that you were warned and decided to do more-or-less dire
 <div class="well">
 Only server installation update was tested.
 If you do GUI installation update, you are on your own.
-Of course, you are welcome to ask questions in <a href="https://openindiana.org/mailman/listinfo/oi-dev">oi-dev</a> mailing list, but prepare that nobody will guide you through update.
+Of course, you are welcome to ask questions in [oi-dev](https://openindiana.org/mailman/listinfo/oi-dev) mailing list, but prepare that nobody will guide you through update.
 </div>
 
 * Do backup.
@@ -1661,7 +1653,7 @@ Of course, you are welcome to ask questions in <a href="https://openindiana.org/
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
-Two following steps are actually better to run under <code>screen(1)</code> or <code>tmux(1)</code>
+Two following steps are actually better to run under `screen(1)` or `tmux(1)`
 </div>
 
 * Look what IPS is going to do.
@@ -2410,15 +2402,15 @@ Then you can use the `pkg update` command with the `-R` option to update all the
 Or, use the `pkg install packagename` with the `-R` option to update specific packages on that environment.
 
 <div class="well">
-When <code>pkg</code> creates new boot environment, it determines its name using <code>auto-be-name</code> image property.
-When prefixed with "time:" string, the remaining part of property is interpreted as <code>strftime(3C)</code> argument.
-If <code>pkg</code> can't produce unique boot environment name based on auto-be-name image property,
+When `pkg` creates new boot environment, it determines its name using `auto-be-name` image property.
+When prefixed with "time:" string, the remaining part of property is interpreted as `strftime(3C)` argument.
+If `pkg` can't produce unique boot environment name based on auto-be-name image property,
 it uses the property as base to generate unique name, appending numerical suffix prefixed by "-" symbol.
 Note, that due to name generation rules, any numerical suffix, prefixed by "-", can be incremented to
-generate unique name, so given "time:openindiana-%Y-%m-%d" <code>auto-be-name image</code> property value
-(which is not recommended), <code>pkg</code> will produce boot environment names ending with current date, current date + 1 and so on.
-By default <code>auto-be-name</code> is set to "time:openindiana-%Y:%m:%d", so that boot environments are named like
-"openindiana-2019:03:29". You can get current value using <code>pkg property</code> command and set it with <code>pkg set-property</code>.
+generate unique name, so given "time:openindiana-%Y-%m-%d" `auto-be-name image` property value
+(which is not recommended), `pkg` will produce boot environment names ending with current date, current date + 1 and so on.
+By default `auto-be-name` is set to "time:openindiana-%Y:%m:%d", so that boot environments are named like
+"openindiana-2019:03:29". You can get current value using `pkg property` command and set it with `pkg set-property`.
 </div>
 
 ### Features of the beadm utility

--- a/docs/handbook/network-communications.md
+++ b/docs/handbook/network-communications.md
@@ -23,9 +23,12 @@ All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/a
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
-<p>This is a <b>DRAFT</b> document which may contain errors!</p>
-<p>Help us improve and expand this site.</p>
-<p>Please see the <b>Contrib</b> section for more details about joining the OpenIndiana Documentation Team.</p>
+This is a **DRAFT** document which may contain errors!
+
+Help us improve and expand this site.
+
+Please see the **Contrib** section for more details about joining the OpenIndiana Documentation Team.
+
 </div>
 
 < Place holder for Introduction content >

--- a/docs/handbook/systems-administration.md
+++ b/docs/handbook/systems-administration.md
@@ -39,8 +39,8 @@ a number of essential concepts central to OpenIndiana system administration.
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
 Administrative commands are usually expected to be run with elevated privileges -
-directly from root user, via <code>sudo(1M)</code> or
-<code>pfexec</code> (if user was granted privileges via RBAC).
+directly from root user, via `sudo(1M)` or
+`pfexec` (if user was granted privileges via RBAC).
 In this document commands which require elevated privileges are prefixed with
 "# ". Commands, which don't require elevated privileges, are prefixed with "$ ".
 </div>
@@ -470,7 +470,7 @@ So a fair amount of stuff has changed there.
 
 </div>
 
-Zones are an OpenIndiana feature that provides <a href="http://www.wikipedia.org/wiki/Operating_system-level_virtualization">operating system-level virtualization</a>. Each zone is managed as a completely separate OpenIndiana machine. Zones have very low overhead and are one of the most efficient forms of OS virtualization.
+Zones are an OpenIndiana feature that provides [operating system-level virtualization](http://www.wikipedia.org/wiki/Operating_system-level_virtualization). Each zone is managed as a completely separate OpenIndiana machine. Zones have very low overhead and are one of the most efficient forms of OS virtualization.
 
 The global zone (GZ) is the operating system itself, which has hardware access. From the global zone, non-global zones (NGZ) are created and booted. Boot time for non-global zones is very fast, often a few seconds. The CPU, network, and memory resources for each zone can be controlled from the global zone, ensuring fair access to system resources. Disk space access is usually controlled by ZFS (with quotas and reservations if needed), as well as mounting of filesystem resources with NFS or lofs. As with other forms of virtualization, each zone is isolated from the other zones – zones cannot see processes or resources used in other zones. The low marginal cost of a zone allows large systems have tens or even hundreds of zones without significant overhead. The theoretical limit to the number of zones on a single platform is 8,192.
 

--- a/pandoc-config.yaml
+++ b/pandoc-config.yaml
@@ -1,0 +1,43 @@
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at https://illumos.org/license/
+# 
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at https://illumos.org/license/
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+
+#
+# Copyright 2021 J. Madgwick.  All rights reserved.
+#
+
+lang: en
+author-meta: The OpenIndiana Project
+numbersections: true
+colorlinks: true
+classoption:
+- oneside
+- a4paper
+geometry:
+- lmargin=20mm
+- rmargin=20mm
+- tmargin=20mm
+- bmargin=25mm
+fontsize: 12pt
+header-includes:
+ - \usepackage{fvextra,tocloft,tcolorbox}
+#Ensure verbatim code blocks have line breaks and do not overflow the page
+ - \DefineVerbatimEnvironment{Highlighting}{Verbatim}{breaklines,breakanywhere,commandchars=\\\{\}}
+ - \DefineVerbatimEnvironment{verbatim}{Verbatim}{breaklines,breakanywhere}
+ - \setmainfont{Liberation Sans}
+ - \setmonofont[Scale=0.8]{Liberation Mono}
+ - \newfontfamily\symbolfont[]{Noto Sans Symbols2}
+ - \setlength{\cftsubsecnumwidth}{2.8em}
+ - \setlength{\cftsubsubsecnumwidth}{3.6em}

--- a/pandoc-filter.lua
+++ b/pandoc-filter.lua
@@ -1,0 +1,52 @@
+--[[
+ CDDL HEADER START
+
+ The contents of this file are subject to the terms of the
+ Common Development and Distribution License (the "License").
+ You may not use this file except in compliance with the License.
+
+ You can obtain a copy of the license at https://illumos.org/license/
+ 
+ When distributing Covered Code, include this CDDL HEADER in each
+ file and include the License file at https://illumos.org/license/
+ If applicable, add the following below this CDDL HEADER, with the
+ fields enclosed by brackets "[]" replaced with your own identifying
+ information: Portions Copyright [yyyy] [name of copyright owner]
+
+ CDDL HEADER END
+
+
+ Copyright 2021 J. Madgwick.  All rights reserved.
+--]]
+
+if FORMAT:match 'latex' then
+    -- Wrap 'Div' block content with a tcolorbox (resembling the website)
+    function Div(elem)
+      if (elem.classes[1] == "well") then
+          elem.content:insert(1,pandoc.RawBlock('latex', '\\begin{tcolorbox}'))
+          elem.content:insert(pandoc.RawBlock('latex', '\\end{tcolorbox}'))
+        return elem
+      end
+    end
+
+    -- Replace image tags with a representative character (symbolfont ensures appropraitre font is used)
+    function RawInline(elem)
+      if (elem.text == "<i class=\"fa fa-info-circle fa-lg\" aria-hidden=\"true\">") then
+        return pandoc.RawInline('latex', '{\\symbolfont 🛈}')
+      elseif (elem.text == "<i class=\"fa fa-exclamation-triangle fa-lg\" aria-hidden=\"true\">") then
+        return pandoc.RawInline('latex', '{\\symbolfont 🛆}')
+      end
+    end
+
+    -- Use the top Header (which is actually the title) as a LaTex title + TOC, reduce other 'Header' levels by one
+    function Header(elem)
+      if (elem.level == 1) then
+        elem.content:insert(1,pandoc.RawInline('latex', '\\title{'))
+        elem.content:insert(pandoc.RawInline('latex', '}\\maketitle\\setcounter{tocdepth}{3}\\tableofcontents\\newpage'))
+        return pandoc.Plain(elem.content)
+      else
+        elem.level = elem.level - 1
+        return elem
+      end
+    end
+end


### PR DESCRIPTION
This implements the **proper** fix mentioned in #181. As described in the commit, not all pages of the docs have been fixed. All pages, other than docs/books, which are generated by makepdf.sh have been fixed.

The pages in docs/books need to be restructured/rewritten as they use lists inside a table which is not proper markdown and cannot be converted to PDF using Pandoc. These pages all need more content. All of this is better done together as a future commit.