### PR TITLE
Replace Freenode details with Libera Chat

### DIFF
--- a/docs/contrib/content.md
+++ b/docs/contrib/content.md
@@ -96,5 +96,5 @@ The docs team can be reached via email: _**docs at openindiana.org**_.
 
 You may also inquire via IRC:
 
-* [#openindiana (freenode)](irc://irc.freenode.net/openindiana)
-* [#oi-dev (freenode)](irc://irc.freenode.net/oi-dev)
+* [#openindiana (libera.chat)](irc://irc.libera.chat/openindiana)
+* [#oi-dev (libera.chat)](irc://irc.libera.chat/oi-dev)

--- a/docs/contrib/getting-started.md
+++ b/docs/contrib/getting-started.md
@@ -40,8 +40,8 @@ The docs team can be reached via email: _**docs at openindiana.org**_.
 
 You may also inquire via IRC:
 
-* [#openindiana (freenode)](irc://irc.freenode.net/openindiana)
-* [#oi-dev (freenode)](irc://irc.freenode.net/oi-dev)
+* [#openindiana (libera.chat)](irc://irc.libera.chat/openindiana)
+* [#oi-dev (libera.chat)](irc://irc.libera.chat/oi-dev)
 </div>
 
 

--- a/docs/dev/userland.md
+++ b/docs/dev/userland.md
@@ -31,7 +31,7 @@ When an update is committed to the oi-userland git repository:
 
 * an automated build is kicked off,
 * then automatically the binary package will be published to the /hipster repository,
-* finally, the status of the build will be reported by oibot to the #oi-dev freenode IRC channel.
+* finally, the status of the build will be reported by oibot to the #oi-dev libera.chat IRC channel.
 
 ### Overview of oi-userland
 
@@ -72,7 +72,7 @@ To build a component you simply cd into the directory of the software, and type 
 <div class="well">
 **Before adding new packages to oi-userland...**
 
-Before considering adding a new package to oi-userland, please check first whether someone else is working on the package by checking the issue tracker, mailing [oi-dev@openindiana.org](mailto:oi-dev@openindiana.org) or asking on the IRC (#oi-dev at irc.freenode.net)
+Before considering adding a new package to oi-userland, please check first whether someone else is working on the package by checking the issue tracker, mailing [oi-dev@openindiana.org](mailto:oi-dev@openindiana.org) or asking on the IRC (#oi-dev at irc.libera.chat)
 
 * If you don't find anyone already working on a port, please register your effort by opening an issue.
 * If you wish to update an existing port, look at the log for the component Makefile ("git log Makefile") and make sure you either contact the person who last updated the Makefile or include them on notifications for the issue by ticking their name.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,20 +29,18 @@
 
 <div class="col-sm-6">
   <div class="panel panel-default">
-    <div class="panel-heading"><a href="irc://irc.freenode.net/openindiana">#openindiana (Freenode)</a></div>
+    <div class="panel-heading"><a href="irc://irc.libera.chat/openindiana">#openindiana (Libera Chat)</a></div>
     <div class="panel-body">
       <ul>
         <li>End user support IRC channel</li>
-        <ul><li><a href="https://freenode.logbot.info/openindiana">Channel Logs</a></li></ul>
       </ul>
     </div>
   </div>
   <div class="panel panel-default">
-    <div class="panel-heading"><a href="irc://irc.freenode.net/oi-dev">#oi-dev (Freenode)</a></div>
+    <div class="panel-heading"><a href="irc://irc.libera.chat/oi-dev">#oi-dev (Libera Chat)</a></div>
     <div class="panel-body">
       <ul>
         <li>Development team IRC channel</li>
-        <ul><li><a href="https://freenode.logbot.info/oi-dev">Channel Logs</a></li></ul>
       </ul>
     </div>
   </div>

--- a/docs/misc/oi-docs.md
+++ b/docs/misc/oi-docs.md
@@ -96,5 +96,5 @@ The docs team can be reached via email: _**docs at openindiana.org**_.
 
 You may also inquire via IRC:
 
-* [#openindiana (freenode)](irc://irc.freenode.net/openindiana)
-* [#oi-dev (freenode)](irc://irc.freenode.net/oi-dev)
+* [#openindiana (libera.chat)](irc://irc.libera.chat/openindiana)
+* [#oi-dev (libera.chat)](irc://irc.libera.chat/oi-dev)

--- a/docs/misc/openindiana.md
+++ b/docs/misc/openindiana.md
@@ -257,8 +257,8 @@ Below is a list of OpenIndiana community resources you may find helpful:
 
 | Resource | URL
 | --- | ---
-| General Discussion IRC channel | [#openindiana on irc.freenode.net](irc://irc.freenode.net/openindiana)
-| Development IRC channel | [#oi-dev on irc.freenode.net](irc://irc.freenode.net/oi-dev)
+| General Discussion IRC channel | [#openindiana on irc.libera.chat](irc://irc.libera.chat/openindiana)
+| Development IRC channel | [#oi-dev on irc.libera.chat](irc://irc.libera.chat/oi-dev)
 | General OpenIndiana Discussion Mailing List | <https://openindiana.org/mailman/listinfo/openindiana-discuss>
 | OpenIndiana Development Mailing List | <https://openindiana.org/mailman/listinfo/oi-dev>
 | illumos Mailing Lists | <https://illumos.org/docs/community/lists/>


### PR DESCRIPTION
Libera Chat has just marked their [one month milestone](https://libera.chat/news/one-month-of-libera-chat). OI has had channels on Libera Chat for much of that time and the old freenode channels have seen little activity since.

All the documentation still refers to freenode. Now that Libera Chat is established, it is possibly time to bring the documentation up to date. More details on the oi-dev mailing list.

This PR also removes links to the logbot website as this is no longer logging and has been shutdown.