### PR TITLE
Pin versions for pip package dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
 mkdocs==1.0.4
 mkdocs-bootstrap==0.1.1
 mkdocs-bootswatch==1.0
+
+Markdown==3.2.2
+livereload==2.6.3
+tornado==6.1
+click==7.1.2
+Jinja2==2.11.3
+PyYAML==5.3.1


### PR DESCRIPTION
GitHub Actions automatically selects a newer version of the "Markdown" package compared to Travis CI (which uses 3.2.2), the newer version has different and incompatible behaviour. This different behaviour causes a rendering problem in the docs.
This happens because the dependency versions required by MkDocs are given as ">=". Since MkDocs 1.0.4 was released there have been many updates to the dependencies and this has now got to the point where the latest version of a dependency may not be compatible anymore.
Pinning these dependencies of MkDocs to a known good version helps to mitigate this problem.
This fixes the problem I mentioned in #191.