### PR TITLE
Add a build only job for Pull Reqs, Add PDFs to the build

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,22 +1,74 @@
 name: Publish docs via GitHub Pages
 on:
   push:
-    branches:
-      - master
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
-  build:
-    name: Deploy docs
+  build-pdf:
+    name: Create PDFs
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install Deps
+        run: |
+          sudo apt-get install texlive-xetex fonts-noto-core
+          wget https://github.com/jgm/pandoc/releases/download/2.11.4/pandoc-2.11.4-1-amd64.deb
+          sudo apt-get install ./pandoc-2.11.4-1-amd64.deb
+
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Change to repository & Build PDFs
+        run: | 
+          cd $GITHUB_WORKSPACE
+          ./makepdf.sh
+
+      - name: Upload PDF Artifact
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: PDFs
+          path: pdf
+          if-no-files-found: error
+
+  build-mkdocs-only:
+    name: Build docs
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
         uses: actions/checkout@v2
 
-      - name: Deploy docs
+      - name: Build mkdocs
+        uses: OpenIndiana/mkdocs-deploy-gh-pages@oi
+        env:
+          CONFIG_FILE: mkdocs.yml
+          EXTRA_PACKAGES: build-base
+
+  build-mkdocs-and-deploy:
+    name: Build & Deploy docs
+    if: ${{ github.event_name == 'push' }}
+    needs: [build-pdf]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v2
+
+      - name: Create dir for PDFs
+        run: mkdir docs/pdf
+
+      - name: Download PDF Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: PDFs
+          path: docs/pdf/
+
+      - name: Build & Deploy mkdocs
         uses: OpenIndiana/mkdocs-deploy-gh-pages@oi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_DOMAIN: docs.openindiana.org
           CONFIG_FILE: mkdocs.yml
           EXTRA_PACKAGES: build-base
-
+          PUBLISH: yes


### PR DESCRIPTION
This implements the idea set out in #195 to allow builds (but not deploy) to occur on PRs. It also adds the ability to automatically build the PDFs and when deploying, adds these to the website.
When deploying, the PDFs are built first and then mkdocs build & deploy is run. When just building based on a PR, the PDF build and mkdocs build are done in parallel (as mkdocs doesn't need the PDFs in order to build).