### PR TITLE
Update and fix broken links

### DIFF
--- a/docs/contrib/getting-started.md
+++ b/docs/contrib/getting-started.md
@@ -68,7 +68,7 @@ After GIT is installed, be sure to configure your name and email address.
 
 For further details about configuring GIT, see: <https://help.github.com/articles/set-up-git/>
 
-Also, if you need a good tutorial for quickly getting up to speed with GIT, see here: <http://rypress.com/tutorials/git/index>
+Also, if you need a good book for quickly getting up to speed with GIT, see here: <https://git-scm.com/book/en/v2>
 
 Fear not though, only basic git commands are required for working with OI-DOCS.
 </div>

--- a/docs/contrib/git.md
+++ b/docs/contrib/git.md
@@ -160,6 +160,6 @@ For further details about configuring GIT, see: <https://help.github.com/article
 
 ## Further Reading
 
-If you're really excited about Git and desire to become a Git Ninja, here is a great tutorial to further your education: <http://rypress.com/tutorials/git/index>
+If you're really excited about Git and desire to become a Git Ninja, here is a great book to further your education: <https://git-scm.com/book/en/v2>
 
 There is also the book [Pro Git](https://git-scm.com/book/en/v2) which is available for free under a Creative Commons license.

--- a/docs/contrib/tools.md
+++ b/docs/contrib/tools.md
@@ -80,7 +80,7 @@ The choice is yours; Use your favorite editor.
 | URL | Description
 |---|---
 | <http://www.mkdocs.org/> | MkDocs Content Authoring Framework
-| <https://pythonhosted.org/Markdown/> | Python implementation of Markdown
+| <https://python-markdown.github.io/> | Python implementation of Markdown
 | <http://spec.commonmark.org/0.25/> | The CommonMark Markdown Spec
 | <https://github.com/mivok/markdownlint> | Markdown Lint
 | <https://travis-ci.org/> | Continuous Integration (similar to Jenkins, etc.)

--- a/docs/contrib/topics.md
+++ b/docs/contrib/topics.md
@@ -406,7 +406,7 @@ This document might also be a good place to put the following topics:
 * Write a table providing a matrix comparing commands between BSD/Linux/OpenIndiana.
     * This could also be something for the handbook.
     * Place it wherever it looks best.
-* See [this page](https://wiki-bsse.ethz.ch/display/ITDOC/Major+difference+between+Linux+and+Solaris) for some inspiration.
+* See [this page](https://web.archive.org/web/20200807095415/https://wiki-bsse.ethz.ch/display/ITDOC/Major+difference+between+Linux+and+Solaris) for some inspiration.
 * Also look at old OpenSolaris website (via the wayback machine) for additional ideas, suggestions, etc.
 
 

--- a/docs/dev/graphics-stack.md
+++ b/docs/dev/graphics-stack.md
@@ -26,7 +26,7 @@ Therefore the Graphic Stack is comprised of:
 * the opensource X11 display server Xorg, client libraries and utilities developed by the [X.org Project](https://www.x.org/),
 * an OpenGL implementation in the form of the opensource [Mesa](https://www.mesa3d.org/) library,
 * and illumos kernel drivers for different graphics adapters provided by the [gfx-drm](https://github.com/illumos/gfx-drm) gate,
-* together with the [libdrm](https://cgit.freedesktop.org/mesa/drm) implementing communication between kernel drivers and user-space components through the Direct Rendering Infrastructure (DRI) protocol.
+* together with the [libdrm](https://gitlab.freedesktop.org/mesa/drm) implementing communication between kernel drivers and user-space components through the Direct Rendering Infrastructure (DRI) protocol.
 
 All these components can be installed using the unified build system [oi-userland](https://github.com/OpenIndiana/oi-userland) or simply installed from the package repositories.
 
@@ -65,7 +65,7 @@ Font components in oi-userland are located in the [components/fonts](https://git
 
 Nvidia provides Solaris x86-64/x86 packages of their proprietary driver for different families of graphic adapters.
 
-The Nvidia driver shipped with OpenIndiana is built using [openindiana/nvidia](https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/components/openindiana/nvidia) component.
+The Nvidia driver shipped with OpenIndiana is built using openindiana/nvidia-XXX [e.g. openindiana/nvidia-470](https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/components/openindiana/nvidia-470) component.
 
 The list of currently supported and legacy drivers is updated on the [Unix Drivers](https://www.nvidia.com/object/unix.html) page.
 
@@ -186,7 +186,7 @@ They require Intel ringbuffer support, which is not implemented.
 
 Reference:
 
-* <https://cgit.freedesktop.org/xorg/driver/xf86-video-intel/tree/src/i915_pciids.h>
+* <https://github.com/torvalds/linux/blob/master/include/drm/i915_pciids.h>
 * <https://en.wikipedia.org/wiki/List_of_Intel_graphics_processing_units>
 * <http://src.illumos.org/source/xref/gfx-drm/usr/src/uts/intel/io/i915/i915_drv.c#294>
 

--- a/docs/dev/graphics-stack.md
+++ b/docs/dev/graphics-stack.md
@@ -156,7 +156,7 @@ Alan Coopersmith pointed to the following documents regarding DRI/KMS:
 * <https://en.wikipedia.org/wiki/Direct_Rendering_Manager>
 * <http://dri.freedesktop.org/wiki/>
 * <https://wiki.archlinux.org/index.php/kernel_mode_setting>
-* <http://lanyrd.com/topics/x-window-system>
+* <https://web.archive.org/web/20170711030533/http://lanyrd.com/topics/x-window-system/>
 
 Additionally, information about driver development:
 

--- a/docs/handbook/common-tasks.md
+++ b/docs/handbook/common-tasks.md
@@ -144,7 +144,7 @@ ITEMS TO WRITE ABOUT:
 ITEMS TO WRITE ABOUT:
 
 * <http://forum.kodi.tv/showthread.php?tid=44315&page=2>
-* <http://lightsandshapes.com/plex-on-smartos.html>
+* <https://web.archive.org/web/20180822163548/http://lightsandshapes.com/plex-on-smartos.html>
 
 </div>
 

--- a/docs/handbook/openindiana-download-mirrors.md
+++ b/docs/handbook/openindiana-download-mirrors.md
@@ -29,7 +29,6 @@ List of DLC Mirrors
  Mirror                                              | Location            | Connectivity | Provided by                             | Mirror site                      | Status
  --------------------------------------------------  | ------------------- | ------------ | --------------------------------------  | -------------------------------- | ------
 <http://dlc.openindiana.org/>                        | London, UK          | 1000Mbit/s   | EveryCity Ltd                           | <http://everycity.co.uk/>        | Main download location
-<ftp://ftp.gtlib.gatech.edu/pub/OpenIndiana/>        | Atlanta, GA (USA)   | 1000Mbit/s   | Georgia Institute of Technology         | <http://www.gtlib.gatech.edu/>   |
 <http://ftp.gtlib.gatech.edu/pub/OpenIndiana/>       | Atlanta, GA (USA)   | 1000Mbit/s   | Georgia Institute of Technology         | <http://www.gtlib.gatech.edu/>   |
 <http://mirror.math.princeton.edu/pub/openindiana>   | Princeton, NJ (USA) | 1000Mbit/s   | Princeton University                    | <https://www.princeton.edu/>     |
 <http://www.ftp.ne.jp/OS/OpenIndiana/>               | Toyko, Japan        | 1000Mbit/s   | KDDI R&D Laboratories Inc.              | <http://www.kddilabs.jp/>        |
@@ -37,4 +36,3 @@ List of DLC Mirrors
 <http://ftp.tsukuba.wide.ad.jp/illumos/openindiana/> | Tsukuba, Japan      | 1000Mbit/s   | Tsukuba WIDE Public Mirror service      | <http://ftp.tsukuba.wide.ad.jp/> |
 <http://iso.nl.netbsd.org/pub/os/openindiana.org/>   | Ede, Netherlands    | 1000Mbit/s   | NLUUG                                   | <https://www.nluug.nl/>          |
 <http://mirrors.dotsrc.org/openindiana/>             | Denmark             | 10000Mbit/s  | Dotsrc.org                              | <https://dotsrc.org/>            |
-<https://ftp.acc.umu.se/mirror/openindiana.org/dlc/> | Umeå, Sweden        | 20000Mbit/s  | Academic Computer Club, Umeå University | <https://ftp.acc.umu.se/about/>  |

--- a/docs/misc/openindiana.md
+++ b/docs/misc/openindiana.md
@@ -99,9 +99,9 @@ OpenIndiana contains the following enterprise class features and more:
 | KVM | [Kernel Virtual Machine - (Operating System Virtualization)](https://en.wikipedia.org/wiki/Kernel-based_Virtual_Machine)
 | Zones | [OS Level Virtualized Application Containers](https://en.wikipedia.org/wiki/Solaris_Containers)
 | Time-Slider | [Automated ZFS Snapshots and Rollbacks](https://web.archive.org/web/20160420090032/http://www.serverwatch.com/tutorials/article.php/3831881/Say-Cheese-OpenSolaris-Time-Slider.htm)
-| RBAC | [Role-Based Access Control](https://web.archive.org/web/20170910053725/http://www.c0t0d0s0.org/archives/4073-Less-known-Solaris-features-RBAC-and-Privileges-Part-1-Introduction.html)
-| IPMP | [IP Network Multipathing](https://web.archive.org/web/20170711060444/http://www.c0t0d0s0.org/archives/6292-Less-known-Solaris-features-IP-Multipathing-Part-1-Introduction.html)
-| DLMP | [Data Link Multipathing](https://web.archive.org/web/20170711022908/http://www.c0t0d0s0.org/archives/7553-Less-known-Solaris-Features-Data-Link-Multipathing.html)
+| RBAC | [Role-Based Access Control](http://www.c0t0d0s0.org/2008-02-04/less-known-solaris-features-rbac-and-privileges-part-1-introduction.c0t0d0s0)
+| IPMP | [IP Network Multipathing](http://www.c0t0d0s0.org/2010-01-21/less-known-solaris-features-ip-multipathing-part-1-introduction.c0t0d0s0)
+| DLMP | [Data Link Multipathing](http://www.c0t0d0s0.org/2013-03-21/less-known-solaris-features-data-link-multipathing.c0t0d0s0)
 
 
 ## What is the OpenIndiana release schedule?

--- a/docs/misc/openindiana.md
+++ b/docs/misc/openindiana.md
@@ -98,10 +98,10 @@ OpenIndiana contains the following enterprise class features and more:
 | COMSTAR |[Common Multiprotocol SCSI TARget - (ISCSI Target Framework)](http://illumos.org/man/1m/itadm)
 | KVM | [Kernel Virtual Machine - (Operating System Virtualization)](https://en.wikipedia.org/wiki/Kernel-based_Virtual_Machine)
 | Zones | [OS Level Virtualized Application Containers](https://en.wikipedia.org/wiki/Solaris_Containers)
-| Time-Slider | [Automated ZFS Snapshots and Rollbacks](http://www.serverwatch.com/tutorials/article.php/3831881/Say-Cheese-OpenSolaris-Time-Slider.htm)
-| RBAC | [Role-Based Access Control](http://www.c0t0d0s0.org/archives/4073-Less-known-Solaris-features-RBAC-and-Privileges-Part-1-Introduction.html)
-| IPMP | [IP Network Multipathing](http://www.c0t0d0s0.org/archives/6292-Less-known-Solaris-features-IP-Multipathing-Part-1-Introduction.html)
-| DLMP | [Data Link Multipathing](http://www.c0t0d0s0.org/archives/7553-Less-known-Solaris-Features-Data-Link-Multipathing.html)
+| Time-Slider | [Automated ZFS Snapshots and Rollbacks](https://web.archive.org/web/20160420090032/http://www.serverwatch.com/tutorials/article.php/3831881/Say-Cheese-OpenSolaris-Time-Slider.htm)
+| RBAC | [Role-Based Access Control](https://web.archive.org/web/20170910053725/http://www.c0t0d0s0.org/archives/4073-Less-known-Solaris-features-RBAC-and-Privileges-Part-1-Introduction.html)
+| IPMP | [IP Network Multipathing](https://web.archive.org/web/20170711060444/http://www.c0t0d0s0.org/archives/6292-Less-known-Solaris-features-IP-Multipathing-Part-1-Introduction.html)
+| DLMP | [Data Link Multipathing](https://web.archive.org/web/20170711022908/http://www.c0t0d0s0.org/archives/7553-Less-known-Solaris-Features-Data-Link-Multipathing.html)
 
 
 ## What is the OpenIndiana release schedule?

--- a/docs/release-notes/2017.04-release-notes.md
+++ b/docs/release-notes/2017.04-release-notes.md
@@ -39,7 +39,7 @@ Image                |      Checksum     |   GPG signature
 
 ## Security changes
 
-This release is the first one to be signed and verifiable by GPG. The OpenIndiana Release Engineering key has key id [0x3a021afadbe31887](https://sks-keyservers.net/pks/lookup?op=get&search=0x3A021AFADBE31887).
+This release is the first one to be signed and verifiable by GPG. The OpenIndiana Release Engineering key has key id 0x3a021afadbe31887.
 
 The public key:
 

--- a/docs/release-notes/2017.10-release-notes.md
+++ b/docs/release-notes/2017.10-release-notes.md
@@ -38,7 +38,7 @@ Image                |      Checksum     |   GPG signature
 
 ## Security
 
-This release is signed and verifiable by GPG. The OpenIndiana Release Engineering key has key id [0x3a021afadbe31887](https://sks-keyservers.net/pks/lookup?op=get&search=0x3A021AFADBE31887).
+This release is signed and verifiable by GPG. The OpenIndiana Release Engineering key has key id 0x3a021afadbe31887.
 
 The public key:
 

--- a/docs/release-notes/2018.04-release-notes.md
+++ b/docs/release-notes/2018.04-release-notes.md
@@ -38,7 +38,7 @@ Image                |      Checksum     |   GPG signature
 
 ## Security
 
-This release is signed and verifiable by GPG. The OpenIndiana Release Engineering key has key id [0x3a021afadbe31887](https://sks-keyservers.net/pks/lookup?op=get&search=0x3A021AFADBE31887).
+This release is signed and verifiable by GPG. The OpenIndiana Release Engineering key has key id 0x3a021afadbe31887.
 
 The public key:
 

--- a/docs/release-notes/2018.10-release-notes.md
+++ b/docs/release-notes/2018.10-release-notes.md
@@ -39,7 +39,7 @@ Image                |      Checksum     |   GPG signature
 
 ## Security
 
-This release is signed and verifiable by GPG. The OpenIndiana Release Engineering key has key id [0x3a021afadbe31887](https://sks-keyservers.net/pks/lookup?op=get&search=0x3A021AFADBE31887).
+This release is signed and verifiable by GPG. The OpenIndiana Release Engineering key has key id 0x3a021afadbe31887.
 
 The public key:
 

--- a/docs/release-notes/2019.04-release-notes.md
+++ b/docs/release-notes/2019.04-release-notes.md
@@ -38,7 +38,7 @@ Image                |      Checksum     |   GPG signature
 
 ## Security
 
-This release is signed and verifiable by GPG. The OpenIndiana Release Engineering key has key id [0x3a021afadbe31887](https://sks-keyservers.net/pks/lookup?op=get&search=0x3A021AFADBE31887).
+This release is signed and verifiable by GPG. The OpenIndiana Release Engineering key has key id 0x3a021afadbe31887.
 
 The public key:
 

--- a/docs/release-notes/2019.10-release-notes.md
+++ b/docs/release-notes/2019.10-release-notes.md
@@ -38,7 +38,7 @@ Image                |      Checksum     |   GPG signature
 
 ## Security
 
-This release is signed and verifiable by GPG. The OpenIndiana Release Engineering key has key id [0x3a021afadbe31887](https://sks-keyservers.net/pks/lookup?op=get&search=0x3A021AFADBE31887).
+This release is signed and verifiable by GPG. The OpenIndiana Release Engineering key has key id 0x3a021afadbe31887.
 
 The public key:
 

--- a/docs/release-notes/2020.04-release-notes.md
+++ b/docs/release-notes/2020.04-release-notes.md
@@ -35,7 +35,6 @@ Image                |      Checksum     |   GPG signature
 
 ## Security
 
-<!-- Correct link to the public key would be http://hkps.pool.sks-keyservers.net/pks/lookup?op=get&search=0x3A021AFADBE31887 , but somehow key is still not updated in web interface -->
 This release is signed and verifiable by GPG. The OpenIndiana Release Engineering key has key id 0x3a021afadbe31887.
 
 The public key (note, the key was updated at 2020-05-05):

--- a/docs/release-notes/2020.10-release-notes.md
+++ b/docs/release-notes/2020.10-release-notes.md
@@ -35,7 +35,6 @@ Image                |      Checksum     |   GPG signature
 
 ## Security
 
-<!-- Correct link to the public key would be http://hkps.pool.sks-keyservers.net/pks/lookup?op=get&search=0x3A021AFADBE31887 , but somehow key is still not updated in web interface -->
 This release is signed and verifiable by GPG. The OpenIndiana Release Engineering key has key id 0x3a021afadbe31887.
 
 The public key (note, the key was updated at 2020-05-05):


### PR DESCRIPTION
- Replace some general topic dead links with similar working equivalents.
- Replace other broken links with update versions (same site different URL or content moved to another website)
- Replace remaining dead links with Wayback Machine versions
- Remove links to mirrors which are not working