### PR TITLE
Fix outdated apt cache in Actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - name: Install Deps
         run: |
+          sudo apt-get update
           sudo apt-get install texlive-xetex fonts-noto-core
           wget https://github.com/jgm/pandoc/releases/download/2.11.4/pandoc-2.11.4-1-amd64.deb
           sudo apt-get install ./pandoc-2.11.4-1-amd64.deb


### PR DESCRIPTION
It seems some builds failed because the apt cache was outdated in the GitHub Actions build image. Updating it every time will prevent this happening again.