### PR TITLE
Migrate System Administration Wiki content

### DIFF
--- a/docs/handbook/network-communications.md
+++ b/docs/handbook/network-communications.md
@@ -57,8 +57,110 @@ Please see the **Contrib** section for more details about joining the OpenIndian
 
 ## Firewalls
 
-* IP packet filtering (IPF)
+Firewalls are used to filter network traffic based on rules set by the system administrator. Firewall can protect your personal computer or whole company's network from unauthorized network while allowing passage of legitimate network traffic.
 
+### IP Filter
+
+OpenIndiana comes with built-in firewall, IP Filter. IP Filter is the stateful packet filtering and network address translation (NAT) mechanism. IP filter can filter any kind of traffic based on source or destination IP address or pool of IP addresses, source or destination ports, interface or direction of the network traffic. OpenIndiana IP Filter is derived from open source IPFilter software.
+
+<i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
+<div class="well">
+To manage IP Filter rules one must assume a role that includes IP Filter Management profile rights or superuser (**root**).
+</div>
+
+### IP Filter configuration
+
+IP Filter is configured by loadable configurations files stored in `/etc/ipf`. One can create several configuration files in `/etc/ipf` for firewall configuration:
+
+- **ipf.conf** - stores packet filtering rules
+- **ipnat.conf** - defines NAT rules
+- **ippol.conf** - address pool configuration
+
+If IP Filter SMF service is enabled then the configured rules will be automatically loaded at every boot time of the operating system.
+
+### Packet Filtering
+
+IP Filter ruleset can be configured with the [ipf(1M)](https://illumos.org/man/1M/ipf) or `/etc/ipf/ipf.conf` file. Rules are processed by the _"the last matching rule wins"_ logic. This means that packet passing the IP Filter ruleset from the beggining and the action of the last rule that matched the packet is applied. There are two exceptions, which change this processing. The first one is the use of **quick** keyword, which will apply the rule on the packet and stop further filter rules checks. Another exception is the **group** keyword, which matches packet. Only rules with **group** keyword are used for packet processing.
+
+#### Filtering rules syntax
+
+The following format is used to create filtering rules:
+
+**action [in|out] option keyword, keyword..**
+
+Every rule begins with the action. Action can be one of these:
+
+- **block** - denies packets from passing the filter
+- **pass** - allows packets to pass the filter
+- **log** - logs the packet. [ipmon(1M)](https://illumos.org/man/1M/ipmon) is used to view the log file.
+- **count** - counts packet into the filter statistics. Use [ipfstat(1M)](https://illumos.org/man/1M/ipfstat) to display the statistics.
+- **skip** number - skips the filter over number filtering rules
+- **auth** - user program is requested to perform packet authentification in order to decide if the packet should be passed or not
+
+Following the action, the next word is **in** or **out**. This determines in which direction rules are applied, e.g incoming or outgoing packets.
+
+The option keyword is next. One can choose from:
+
+- **log** - logs the packet is the packet matched the rule. Use [ipmon(1M)](https://illumos.org/man/1M/ipmon) to view the log.
+- **quick** - rule with quick keyword is executed if packet matches it. No further rules checking is done.
+- **on** interface - rule is applied only on interface in both directions
+- **dup-to** interface - packet is copied and sent out on interface to specified IP address
+- **to** interface - packet is moved to an outbound queue on interface
+
+Next are the keywords that determine if the packet matches the rule. The following keywords shown here can be used:
+
+- **tos** - packet is filtered based on the type-of-service value written as decimal or hexadecimal integer.
+- **ttl**- packet is matched based on its time-to-live value.
+- **proto** - used to match a specific protocol. Any protocol name from /etc/protocols or its decimal representation can be used.
+- **from/to/all/any** - matches either source or destination IP address of the packet and the port number. All accepts packet from any source to any destination.
+- **with** - matches specified attributes associated with the packet. Inserted not/no in front of the keyword matches the packet only if the option is not present.
+- **flags** - filters based on TCP flags that are set.
+- **icmp-type** - filters based on ICMP type.
+- **keep** keep-options - determines whetever state should be kept for a packet. state stores information about the session and can be kept on TCP, UDP, and ICMP packets. The frags keeps information about packet fragments and apllies them to later fragments. This option allows matching packets to pass without further ruleset evalution.
+- **head** number - creates new group for filtering rules denoted by number.
+- **group** number - adds the rule to group number. The default group value is 0.
+
+In the following example we will block all incoming packet on igb0 from 10.0.0.0/8. This rule should be included in one's ruleset:
+
+`block in quick on igb0 from 10.0.0.0/8 to any`
+
+#### Address pools
+
+Address pools group multiple IP addresses/networks into a single reference that can be used in IP Filter rules.
+
+## NAT (Network Address Translation)
+
+NAT is used in case when one needs to do address or port translation. This happens when one wants to connect multiple computers at home and share the network connection or when one wants to do port forwarding. NAT on OpenIndiana is set up in `/etc/ipf/ipnat.conf` and work regarding NATs is done with [ipnat(1M)](https://illumos.org/man/1M/ipnat).
+
+### NAT rules syntax
+
+To create NAT rules use the following syntax:
+
+command interface-name parameters
+
+Every rule begins with command from one of these:
+
+- **map** - maps one IP address or network to another IP address or network.
+- **rdr** - redirects packet from one IP address and port to another IP address and port.
+- **bimap** - creates bidirectorial NAT between an external and an internal IP address.
+- **map-block** - establishes static IP address-based translation.
+
+Interface named is used after command, e.g. **igb0**.
+
+To determine NAT configuration one has to use one of the following parameters:
+
+- **ipmask** - designates the network mask.
+- **dstipmask** - designates the address ipmask is translated to.
+- **mapport** - designates TCP or UDP protocols along with range of ports.
+
+Assuming we have an external IP address 10.0.0.1/24 on interface eg1000 and an internal range of 192.168.1.0/24. The example NAT rule would look like this:
+
+`map eg1000 192.168.0.0/24 -> 10.0.0.1/24`
+
+<i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
+<div class="well">
+NAT is not usable with IPv6 IP filter as NAT is deprecated in IPv6. NAT can be only used with IPv4 addresses.
+</div>
 
 ## Advanced Networking
 

--- a/docs/handbook/systems-administration.md
+++ b/docs/handbook/systems-administration.md
@@ -490,12 +490,6 @@ ITEMS TO WRITE ABOUT:
 
 < place holder >
 
-
-### Role based access control (RBAC)
-
-< place holder >
-
-
 ## Zones
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **DOC TEAM NOTE:**
@@ -896,9 +890,6 @@ Possible resources to help write this section:
 
 
 ## Configuring Networking
-
-< Place Holder >
-
 
 ### Manual Configuration (static IP)
 

--- a/docs/handbook/systems-administration.md
+++ b/docs/handbook/systems-administration.md
@@ -306,11 +306,9 @@ There are at least three different possible approaches for Active Directory auth
 #### Native AD integration
 
 - Pro: Fully integrated and native tools only
-- Cons: Works only for Solaris (Openindiana) CIFS and NFS service, unless you use enable directory-based name mapping and install IDMU (Identity Management for UNIX) on the AD server.
+- Cons: Doesn't work for UNIX services other than CIFS and NFS. The ephemeral id mapping strategy supposedly wasn't designed for other UNIX services. As a result several problems arrise, one of them is that the mappings aren't constant over the lifetime of UNIX processes which severly breaks UNIX semantics. Depending on your UNIX service you will see unexpected results or even process crashing.
 
-This approach works out of the box for CIFS and NFS services. It doesn't work out of the box for other UNIX services because the ephemeral id mapping strategy supposedly wasn't designed for other UNIX services. As a result several problems arrise, one of them is that the mappings aren't constant over the lifetime of UNIX processes which severly breaks UNIX semantics. Depending on your UNIX service you will see unexpected results or even process crashing.
-
-In order to use this approach with any UNIX service (eg **Netatalk**) you need to enable _directory-based name mapping_ and install **IDMU** (Identity Management for UNIX) on the AD server.
+In order to use this approach with any UNIX service (eg **FTP**) you need to enable _directory-based name mapping_ and install **IDMU** (Identity Management for UNIX) on the AD server.
 
 Refer to the original documentation from Oracle for getting this working: [nss_ad](http://docs.oracle.com/cd/E23824_01/html/821-1455/adsetup-10.html), [CIFS](http://docs.oracle.com/cd/E19963-01/html/821-1449/manageidmutm.html).
 

--- a/docs/handbook/systems-administration.md
+++ b/docs/handbook/systems-administration.md
@@ -431,6 +431,40 @@ onto the system before changing the run-level.
 < place holder >
 
 
+### Virtual Terminals/Consoles (VT)
+Virtual Terminals/Virtual Consoles (VT) are used to switch between terminals and using system in text mode with _Ctrl+Alt+F1,F2..F8_ key combinations.
+
+<i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
+<div class="well">
+Switching to VTs using _Ctrl+Alt+Fn_ during current desktop session (at **VT7**) can result in **X server** and **lightdm** (or **gdm**) restarting and stopping all applications running within it.
+Currently, there could be problems with getting back to gdm/Xorg session if switching to VTs after gdm restart. Use `svcadm restart ligthdm` (or `svcadm restart gdm`) command again, to have lightdm/gdm Xorg session restarted at **VT8** (_Ctrl+Alt+F8_).
+</div>
+
+At fresh Openindiana install, VT/Consoles are **not enabled by default**. One needs to set up vtdaemon and console-login:vt2 (till :vt6) and enable **vtdaemon** options/hotkeys property:
+
+```
+pfexec svcadm enable vtdaemon
+pfexec svcadm enable console-login:vt2
+pfexec svcadm enable console-login:vt3
+pfexec svcadm enable console-login:vt4
+pfexec svcadm enable console-login:vt5
+pfexec svcadm enable console-login:vt6
+```
+
+Or do that in a one-liner Bash script: `for i in 2 3 4 5 6 ; do pfexec svcadm enable console-login:vt$i; done;`
+
+Then, enable options/hotkeys property (_Ctrl+Alt+Fn_) to switch VTs and refresh and restart **vtdaemon** service:
+
+```
+pfexec svccfg -s vtdaemon setprop options/hotkeys=true
+pfexec svcadm refresh vtdaemon
+pfexec svcadm restart vtdaemon
+```
+
+Optionally, you can also disable VT consoles auto screen locking (recommended for personal use, not recommended on server): `pfexec svccfg -s vtdaemon setprop options/secure=false`
+
+The above was inspired by [this blog by Danx on Virtual Consoles](https://web.archive.org/web/20160424040330/https://blogs.oracle.com/DanX/entry/solaris_virtual_consoles).
+
 ### Service management (SMF)
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **DOC TEAM NOTE:**

--- a/docs/handbook/systems-administration.md
+++ b/docs/handbook/systems-administration.md
@@ -293,6 +293,47 @@ Now user whoever can shutdown the system.
 The `pfexec` command is more flexible in the number of privileges that can be
 assigned to a user.
 
+### Active Directory Integration
+
+#### Introduction
+
+There are at least three different possible approaches for Active Directory authentication and each has its pros and cons.
+
+1. Use the new native AD integration with **idmap**, **nss_ad** and **kclient**, this will work with CIFS and NFS out of the box.
+2. Use Kerberos and LDAP (**kclient**, **ldapclient**, **pam_krb5** and **nss_ldap**).
+3. Use **windbind** (**pam_winbind** and **nss_winbind**).
+
+#### Native AD integration
+
+- Pro: Fully integrated and native tools only
+- Cons: Works only for Solaris (Openindiana) CIFS and NFS service, unless you use enable directory-based name mapping and install IDMU (Identity Management for UNIX) on the AD server.
+
+This approach works out of the box for CIFS and NFS services. It doesn't work out of the box for other UNIX services because the ephemeral id mapping strategy supposedly wasn't designed for other UNIX services. As a result several problems arrise, one of them is that the mappings aren't constant over the lifetime of UNIX processes which severly breaks UNIX semantics. Depending on your UNIX service you will see unexpected results or even process crashing.
+
+In order to use this approach with any UNIX service (eg **Netatalk**) you need to enable _directory-based name mapping_ and install **IDMU** (Identity Management for UNIX) on the AD server.
+
+Refer to the original documentation from Oracle for getting this working: [nss_ad](http://docs.oracle.com/cd/E23824_01/html/821-1455/adsetup-10.html), [CIFS](http://docs.oracle.com/cd/E19963-01/html/821-1449/manageidmutm.html).
+
+#### Kerberos and LDAP
+
+- Pro: Fully integrated and native tools only
+- Cons: Requires installation of additional role services (IDMU, Identity Management for UNIX) on the Active Directory side
+
+<i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **DOC TEAM NOTE:**
+<div class="well">
+On the Wiki the 'Kerberos and LDAP' page was a separate detailed article on configuration of Windows Server 2008 Active Directory to work with OI. As of 2021, Windows Server 2008 is EoL. This section should not be migrated until it has been checked and updated for recent Windows. Ideally this information should be on a separate page (potentially community contributions) as it’s large and contains a lot of Windows information.
+</div>
+
+#### winbind
+
+- Pro: Easy setup, no AD modification
+- Cons: Depends on 3rd party software (Samba), group membership resolution didn't work
+
+<i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **DOC TEAM NOTE:**
+<div class="well">
+As above note, the 'winbind' page was a separate detailed article which needs to be checked and updated before it's migrated.
+</div>
+
 ## Management of System Resources
 
 ### Basic system information

--- a/docs/handbook/systems-administration.md
+++ b/docs/handbook/systems-administration.md
@@ -432,6 +432,7 @@ onto the system before changing the run-level.
 
 
 ### Virtual Terminals/Consoles (VT)
+
 Virtual Terminals/Virtual Consoles (VT) are used to switch between terminals and using system in text mode with _Ctrl+Alt+F1,F2..F8_ key combinations.
 
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**


### PR DESCRIPTION
Migrate some of the remaining content from the System Administration section (4) of the old Wiki.
There's still some content left to check/update.