### PR TITLE
Tidy up Community pages

### DIFF
--- a/docs/handbook/community.md
+++ b/docs/handbook/community.md
@@ -21,80 +21,6 @@ All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/a
 
 # Hipster Handbook - Community Tutorials
 
-
-## How to Install Oracle Databases (Native or Vagrant) on OpenIndiana Hipster
-
-Originally contributed by OpenIndiana community member Franklin Ronald, Franklin Ronald's article details the steps required for the native installation of Oracle Database 11R2 on OpenIndiana Hipster.  Alternatively it is possible to run Oracle RAC or any other Oracle Database software using VirtualBox and Vagrant.
-
-Link to PDF Document: [How to Install Oracle Database 11R2 on OpenIndiana Hipster](../pdf/HowToInstallOracleDB.pdf)
-
-<i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
-<div class="well">
-It is not recommended to run Oracle Database on OpenIndiana in a production environment. Oracle has a restricted list of supported operating systems and unfortunately OpenIndiana is not in it. The purpose of the Installing 11R2 on OI article is to install the Oracle Database for use in a development environment.
-</div>
-
-For development purposes it is also possible to setup Oracle Database 18, 19 and 21.3 using Vagrant.  See the Vagrant documentation for more information.
-
-Vagrantfile are provided by Oracle, for testing products such as the Oracle Database.
-
-As ordinary login user do:
-
-```none
-        $ mkdir -p /scratch/oracle/vagrant-projects
-```
-
-Then clone the Oracle vagrant projects :
-
-```none
-        $ cd /scratch/oracle/vagrant-projects
-        $ git clone https://github.com/oracle/vagrant-projects.git .
-```
-
-Some interesting Oracle Database products can be built :
-
-```none
-        $ cd /scratch/oracle/vagrant-projects
-        $ cd OracleDatabase/
-        $ ls
-        11.2.0.2   12.2.0.1   18.4.0-XE  21.3.0
-        12.1.0.2   18.3.0     19.3.0     README.md
-```
-
-For example to build a 21.3 Oracle Database provided you can download from OTN (Oracle Tech Net) the LINUX.X64_213000_db_home.zip Oracle product :
-
-```none
-        $ cd 21.3.0
-        $ vagrant up
-        Bringing machine 'oracle-21c-vagrant' up with 'virtualbox' provider...
-        ==> oracle-21c-vagrant: Importing base box 'oraclelinux/8'...
-        ==> oracle-21c-vagrant: Matching MAC address for NAT networking...
-
-        ... lots of messages ---
-
-        oracle-21c-vagrant: Oracle Database 21c Enterprise Edition Release 21.0.0.0.0 - Production
-        oracle-21c-vagrant: Version 21.3.0.0.0
-```
-
-This is an example Vagrantfile to deploy a VirtualBox VM called oracle-21c-vagrant running Linux and Oracle Database 21c.
-
-## How to Install Sun Ray Software on OpenIndiana Hipster
-
-This article, contributed by OpenIndiana community member Carsten Grzemba, details the steps required for the installation of Sun Ray Software on OpenIndiana Hipster.
-
-Link to document: [Sun Ray Software on OpenIndiana Hipster](../handbook/sunray.md)
-
-## How to Install Vagrant on OpenIndiana Hipster
-
-Link to Vagrant Document: [Vagrant on OpenIndiana Hipster](vagrant/index.html)
-
-## How to Install the TeX Live Typesetting Software on OpenIndiana Hipster
-
-Link to TeXLive Document: [OpenIndiana Hipster Notes for TeX Live Users](texlive/index.html)
-
-## How to Install Squeak Smalltalk-80 on OpenIndiana Hipster
-
-Link to Squeak Document: [OpenIndiana Hipster Notes for Squeak Users](squeak/index.html)
-
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **Call for Contributors:**
 <div class="well">
 Help us improve and expand this page by offering your community written tutorials for publication on this site.
@@ -102,3 +28,26 @@ Help us improve and expand this page by offering your community written tutorial
 Please see the **Contrib** section for more details. The docs team can be reached via email: **docs at openindiana.org.**
 </div>
 
+## How to Install Oracle Databases (Native or Vagrant) on OpenIndiana Hipster
+
+Originally contributed by OpenIndiana community member Franklin Ronald, this article details the steps required for the native installation of Oracle Database 11R2 on OpenIndiana Hipster.
+
+Link to article: [Installing Oracle Databases (Native or Vagrant) on OpenIndiana Hipster](community/oracledb.md)
+
+## How to Install Sun Ray Software on OpenIndiana Hipster
+
+This article, contributed by OpenIndiana community member Carsten Grzemba, details the steps required for the installation of Sun Ray Software on OpenIndiana Hipster.
+
+Link to document: [Sun Ray Software on OpenIndiana Hipster](sunray.md)
+
+## How to Install Vagrant on OpenIndiana Hipster
+
+Link to Vagrant Document: [Vagrant on OpenIndiana Hipster](community/vagrant.md)
+
+## How to Install the TeX Live Typesetting Software on OpenIndiana Hipster
+
+Link to TeXLive Document: [OpenIndiana Hipster Notes for TeX Live Users](community/texlive.md)
+
+## How to Install Squeak Smalltalk-80 on OpenIndiana Hipster
+
+Link to Squeak Document: [OpenIndiana Hipster Notes for Squeak Users](community/squeak.md)

--- a/docs/handbook/community/oracledb.md
+++ b/docs/handbook/community/oracledb.md
@@ -1,0 +1,77 @@
+<!--
+
+The contents of this Documentation are subject to the Public Documentation License Version 1.01
+ (the "License"); you may only use this Documentation if you comply with the terms of this License.
+A copy of the License is available at http://illumos.org/license/PDL.
+
+
+The Original Documentation is _________________.
+
+The Initial Writer of the Original Documentation is ___________ Copyright (C)_________[Insert year(s)].
+All Rights Reserved. (Initial Writer contact(s):________________[Insert hyperlink/alias]).
+
+Contributor(s): ______________________________________.
+
+Portions created by ______ are Copyright (C)_________[Insert year(s)].
+All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/alias]).
+
+-->
+
+<img src = "../../../Openindiana.png">
+
+# Hipster Handbook - Installing Oracle Databases (Native or Vagrant)
+
+Originally contributed by OpenIndiana community member Franklin Ronald, Franklin Ronald's article details the steps required for the native installation of Oracle Database 11R2 on OpenIndiana Hipster.  Alternatively it is possible to run Oracle RAC or any other Oracle Database software using VirtualBox and Vagrant.
+
+Link to PDF Document: [How to Install Oracle Database 11R2 on OpenIndiana Hipster](../pdf/HowToInstallOracleDB.pdf)
+
+<i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
+<div class="well">
+It is not recommended to run Oracle Database on OpenIndiana in a production environment. Oracle has a restricted list of supported operating systems and unfortunately OpenIndiana is not in it. The purpose of the Installing 11R2 on OI article is to install the Oracle Database for use in a development environment.
+</div>
+
+For development purposes it is also possible to setup Oracle Database 18, 19 and 21.3 using Vagrant.  See the Vagrant documentation for more information.
+
+Vagrantfile are provided by Oracle, for testing products such as the Oracle Database.
+
+As ordinary login user do:
+
+```none
+        $ mkdir -p /scratch/oracle/vagrant-projects
+```
+
+Then clone the Oracle vagrant projects :
+
+```none
+        $ cd /scratch/oracle/vagrant-projects
+        $ git clone https://github.com/oracle/vagrant-projects.git .
+```
+
+Some interesting Oracle Database products can be built :
+
+```none
+        $ cd /scratch/oracle/vagrant-projects
+        $ cd OracleDatabase/
+        $ ls
+        11.2.0.2   12.2.0.1   18.4.0-XE  21.3.0
+        12.1.0.2   18.3.0     19.3.0     README.md
+```
+
+For example to build a 21.3 Oracle Database provided you can download from OTN (Oracle Tech Net) the LINUX.X64_213000_db_home.zip Oracle product :
+
+```none
+        $ cd 21.3.0
+        $ vagrant up
+        Bringing machine 'oracle-21c-vagrant' up with 'virtualbox' provider...
+        ==> oracle-21c-vagrant: Importing base box 'oraclelinux/8'...
+        ==> oracle-21c-vagrant: Matching MAC address for NAT networking...
+
+        ... lots of messages ---
+
+        oracle-21c-vagrant: Oracle Database 21c Enterprise Edition Release 21.0.0.0.0 - Production
+        oracle-21c-vagrant: Version 21.3.0.0.0
+```
+
+This is an example Vagrantfile to deploy a VirtualBox VM called oracle-21c-vagrant running Linux and Oracle Database 21c.
+</div>
+

--- a/docs/handbook/sunray.md
+++ b/docs/handbook/sunray.md
@@ -17,7 +17,9 @@ All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/a
 
 -->
 
-# Sun Ray Software on OpenIndiana Hipster
+<img src = "../../Openindiana.png">
+
+# Hipster Handbook - Sun Ray Software
 
 Some notes for installation of Sun Ray Software on OpenIndiana Hipster.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,13 @@ nav:
                 - 'Systems Administration': handbook/systems-administration.md
                 - 'Network Communications': handbook/network-communications.md
                 - 'Appendix': handbook/appendix.md
-                - 'Community Contributed Tutorials': handbook/community.md
+                - 'Community Contributed Tutorials':
+                         - 'About Community Contributed Tutorials': handbook/community.md
+                         - 'Oracle Database Installation': handbook/community/oracledb.md
+                         - 'Sun Ray Installation': handbook/sunray.md
+                         - 'Squeak Smalltalk-80 Installation': handbook/community/squeak.md
+                         - 'TeX Live Typesetting Software Installation': handbook/community/texlive.md
+                         - 'Vagrant Installation': handbook/community/vagrant.md
                 - 'Community Hardware Compatibility List':
                          - 'Getting information about hardware': community-hcl/getting-hardware-info.md
                          - 'Components': community-hcl/components.md
@@ -68,5 +74,5 @@ nav:
 extra:
         theme_inverse: true
 
-copyright: Copyright &copy; 2020 <a href="https://www.openindiana.org">The OpenIndiana Project</a>
+copyright: Copyright &copy; 2021 <a href="https://www.openindiana.org">The OpenIndiana Project</a>
 


### PR DESCRIPTION
Community pages didn't have their own links from the navigation menu, this fixes that. It also moves the Oracle Database info onto its own page. There's also a few fixes to ensure a consistent style across pages.