### PR TITLE
Add a page linking to PDF versions of the Handbook

### DIFF
--- a/docs/contrib/tools.md
+++ b/docs/contrib/tools.md
@@ -20,9 +20,11 @@ All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/a
 
 # Contributor Tools
 
+## Introduction
+
 The OpenIndiana Docs website uses 2 principal technologies and several ancillary technologies:
 
-#### Principal technologies:
+### Principal technologies:
 
 * The MkDocs content authoring framework.
 * The Markdown text markup language.
@@ -30,7 +32,7 @@ The OpenIndiana Docs website uses 2 principal technologies and several ancillary
 Both technologies leverage the Python programming language.
 
 
-#### Ancillary technologies:
+### Ancillary technologies:
 
 * GitHub - GIT repository hosting
 * GitHub Pages - Website publishing from a GitHub repository

--- a/docs/contrib/topics.md
+++ b/docs/contrib/topics.md
@@ -25,6 +25,8 @@ The goal of this page is to provide a 'TO DO' list of things which need to be do
 The organization of the resources below are listed first according to the document title they pertain to, followed by individual topics found within that particular document title.
 For each document the published URL and internal site path to the document have been provided.
 
+## Introduction
+
 ### Potentially useful reference information
 
 Below you will find a list of links, most of which are from the Internet Archive 'Wayback' machine.

--- a/docs/handbook/pdfdocs.md
+++ b/docs/handbook/pdfdocs.md
@@ -1,0 +1,64 @@
+<!--
+
+The contents of this Documentation are subject to the Public Documentation License Version 1.01
+ (the "License"); you may only use this Documentation if you comply with the terms of this License.
+A copy of the License is available at http://illumos.org/license/PDL.
+
+
+The Original Documentation is _________________.
+
+The Initial Writer of the Original Documentation is ___________ Copyright (C)_________[Insert year(s)].
+All Rights Reserved. (Initial Writer contact(s):________________[Insert hyperlink/alias]).
+
+Contributor(s): ______________________________________.
+
+Portions created by ______ are Copyright (C)_________[Insert year(s)].
+All Rights Reserved. (Contributor contact(s):________________[Insert hyperlink/alias]).
+
+-->
+
+<img src = "../../Openindiana.png">
+
+# Hipster Handbook - PDF Documentation
+
+Most pages in the Handbook can be downloaded in PDF format. They use a style similar to this website.
+They can also be generated using the old SunBook formatting style, see [Generating PDFs](../contrib/getting-started.md#generating-pdfs-locally) for further details.
+
+## PDF Page Downloads
+
+### About
+- [About OpenIndiana](../pdf/misc/openindiana.pdf)
+- [About OpenIndiana Docs](../pdf/misc/oi-docs.pdf)
+- [OpenIndiana Code of Conduct](../pdf/misc/conduct.pdf)
+- [Public Documentation License](../pdf/misc/pdl.pdf)
+
+### Handbook
+- [Getting Started](../pdf/handbook/getting-started.pdf)
+- [Common Tasks](../pdf/handbook/common-tasks.pdf)
+- [Systems Administration](../pdf/handbook/systems-administration.pdf)
+- [Network Communications](../pdf/handbook/network-communications.pdf)
+- [Appendix](../pdf/handbook/appendix.pdf)
+- [About Community Contributed Tutorials](../pdf/handbook/community.pdf)
+- [Oracle Database Installation](../pdf/handbook/community/oracledb.pdf)
+- [Sun Ray Installation](../pdf/handbook/sunray.pdf)
+- [Squeak Smalltalk-80 Installation](../pdf/handbook/community/squeak.pdf)
+- [TeX Live Typesetting Software Installation](../pdf/handbook/community/texlive.pdf)
+- [Vagrant Installation](../pdf/handbook/community/vagrant.pdf)
+- [Building OpenIndiana](../pdf/dev/building-openindiana.pdf)
+- [Building with oi-userland](../pdf/dev/userland.pdf)
+- [Building legacy consolidations](../pdf/dev/legacy-consolidations.pdf)
+- [Graphics stack](../pdf/dev/graphics-stack.pdf)
+- [Using distribution constructor](../pdf/dev/distribution-constructor.pdf)
+- [Existing tasks](../pdf/dev/existing-tasks.pdf)
+- [Cleaning up OpenIndiana repository](../pdf/dev/repo-cleanup.pdf)
+
+### Contrib
+
+- [Content Creation](../pdf/contrib/content.pdf)
+- [Getting Started](../pdf/contrib/getting-started.pdf)
+- [Contributor Tools](../pdf/contrib/tools.pdf)
+- [Contributor Roles](../pdf/contrib/roles.pdf)
+- [Contributor Topics](../pdf/contrib/topics.pdf)
+- [Contributor Style Guide](../pdf/contrib/style.pdf)
+- [Markdown Syntax Guide](../pdf/contrib/markdown.pdf)
+- [Git Usage Guide](../pdf/contrib/git.pdf)

--- a/docs/handbook/pdfdocs.md
+++ b/docs/handbook/pdfdocs.md
@@ -27,12 +27,14 @@ They can also be generated using the old SunBook formatting style, see [Generati
 ## PDF Page Downloads
 
 ### About
+
 - [About OpenIndiana](../pdf/misc/openindiana.pdf)
 - [About OpenIndiana Docs](../pdf/misc/oi-docs.pdf)
 - [OpenIndiana Code of Conduct](../pdf/misc/conduct.pdf)
 - [Public Documentation License](../pdf/misc/pdl.pdf)
 
 ### Handbook
+
 - [Getting Started](../pdf/handbook/getting-started.pdf)
 - [Common Tasks](../pdf/handbook/common-tasks.pdf)
 - [Systems Administration](../pdf/handbook/systems-administration.pdf)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
                          - 'Using distribution constructor': dev/distribution-constructor.md
                          - 'Existing tasks': dev/existing-tasks.md
                          - 'Cleaning up OpenIndiana repository': dev/repo-cleanup.md
+                - 'PDF Documentation': handbook/pdfdocs.md
         
         - 'OpenSolaris Books':
                 - 'About OpenSolaris Books': books/about.md


### PR DESCRIPTION
The PDF version of pages have been available for a while now. It's time there was a page linking to them.
Also includes some fixes for indentation level consistency (fixes PDFs contents page formatting).