### PR TITLE
Update the docs history section + Replace references to Travis with GitHub Actions

### DIFF
--- a/docs/contrib/roles.md
+++ b/docs/contrib/roles.md
@@ -75,4 +75,4 @@ Upon receipt of a pull request, the content reviewer performs the following step
 * If changes are extensive or involve inline html, the content reviewer may check out your pull request (PR) to perform QA testing.
 * QA testing is performed by running MkDocs in development mode.
 * Upon acceptance, merges the pull request into the mainline branch.
-* Upon merge, the site is automatically published via Travis-CI.
+* Upon merge, the site is automatically published via GitHub Actions.

--- a/docs/contrib/tools.md
+++ b/docs/contrib/tools.md
@@ -32,13 +32,13 @@ Both technologies leverage the Python programming language.
 
 #### Ancillary technologies:
 
-* GitHub - GIT repository hosting
+* GitHub - Git repository hosting
 * GitHub Pages - Website publishing from a GitHub repository
-* GIT - Distributed version control
-* Travis-CI - Continuous Integration toolset
+* GitHub Actions - Continuous Integration toolset
+* Git - Distributed version control
 
 
-## Why use GIT distributed version control for docs?
+## Why use Git distributed version control for docs?
 
 * Integrity - You can roll back to previous versions
 * Mobility - You can edit docs anywhere, no Internet connection required
@@ -83,7 +83,6 @@ The choice is yours; Use your favorite editor.
 | <https://python-markdown.github.io/> | Python implementation of Markdown
 | <http://spec.commonmark.org/0.25/> | The CommonMark Markdown Spec
 | <https://github.com/mivok/markdownlint> | Markdown Lint
-| <https://travis-ci.org/> | Continuous Integration (similar to Jenkins, etc.)
 | <https://pages.github.com/> | Publish from your github repo
 
 
@@ -100,7 +99,7 @@ The gh-pages branch is used to publish the site to GitHub pages.
 
 ## Docs site publishing
 
-Following the best practices of continuous integration, the OpenIndiana Docs website is fully automated using Travis-CI.
-Upon a commit to the site GitHub repository, Travis-CI immediately performs a series of validation tests.
+Following the best practices of continuous integration, the OpenIndiana Docs website is fully automated using GitHub Actions.
+Upon a pull request or commit to the site GitHub repository, GitHub Actions immediately performs a series of validation tests.
 If the validation tests pass, then the website is automatically published to Github Pages.
 

--- a/docs/misc/oi-docs.md
+++ b/docs/misc/oi-docs.md
@@ -41,6 +41,8 @@ The docs team began by looking at:
 * The methods and toolkits used to create past and present documentation.
 * How other projects where approaching their systems documentation efforts.
 
+Much of the migration from the previous Confluence based Wiki was completed in 2019.
+In 2021 the previous Wiki had to been taken offline due to vulnerabilities in the Confluence software it used.
 
 ## Documentation revitalization effort goals
 


### PR DESCRIPTION
- It seemed like it might be useful to mention the old Wiki in the history section.
- Travis is no longer used.