### PR TITLE
Remove references to OSDisc.com which has shut down

### DIFF
--- a/docs/handbook/getting-started.md
+++ b/docs/handbook/getting-started.md
@@ -301,9 +301,6 @@ For a complete list of alternate mirrors (Asia, Europe, North America, etc.)
 
 * [OpenIndiana Download Mirrors](./openindiana-download-mirrors.md)
 
-
-If you wish to purchase a ready made DVD or USB drive there is also [OSDISC.COM](https://www.osdisc.com/products/solaris/openindiana).
-
 Download example:
 
 ```

--- a/docs/misc/openindiana.md
+++ b/docs/misc/openindiana.md
@@ -171,9 +171,6 @@ Alternate mirrors (Asia, Europe, and North America)
 * [OpenIndiana Mirrors](../handbook/openindiana-download-mirrors.md)
 
 
-If you wish to purchase a ready made DVD or USB drive there is also [OSDISC.COM](https://www.osdisc.com/products/solaris/openindiana).
-
-
 <i class="fa fa-info-circle fa-lg" aria-hidden="true"></i> **NOTE:**
 <div class="well">
 For detailed information about creating a bootable OpenIndiana DVD or USB flash drive, please consult the following sections of the OpenIndiana Handbook:


### PR DESCRIPTION
OSDisc.com is no longer operating. See #213. This removes the references/broken links to it.