### PR TITLE
Manually specify Python pip markupsafe version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ livereload==2.6.3
 tornado==6.1
 click==7.1.2
 Jinja2==2.11.3
+markupsafe==2.0.1
 PyYAML==5.4


### PR DESCRIPTION
Required to fix this build error:
```
ImportError: cannot import name 'soft_unicode' from 'markupsafe'
```
Which is caused changes in the latest version of markupsafe (2.1.1)