### PR TITLE
Remove a few references to the old Wiki

### DIFF
--- a/docs/handbook/getting-started.md
+++ b/docs/handbook/getting-started.md
@@ -234,8 +234,8 @@ Installing OpenIndiana on unsupported hardware may cause excessive CPU usage, in
 Please be sure to consult the hardware compatibility list (HCL):
 
 * [Illumos HLC](https://www.illumos.org/hcl/)
-* [OpenIndiana HCL - components](https://wiki.openindiana.org/oi/Components)
-* [OpenIndiana HCL - systems](https://wiki.openindiana.org/oi/Systems)
+* [OpenIndiana HCL - components](../community-hcl/components)
+* [OpenIndiana HCL - systems](../community-hcl/systems)
 
 </div>
 
@@ -875,10 +875,7 @@ The Firefox web browser will open to the 'OpenIndiana Releases' page of the Open
 This however, is not where you will find the release notes.
 _**A bug has been opened to correct this issue**_.
 
-The release notes may be accessed in one of the following ways:
-
-* Perform a search within the Wiki site for the release notes.
-* Browse to the following Wiki page: <https://wiki.openindiana.org/oi/Release+Notes>.
+The release notes can be found [on this page](../release-notes/latest-changes).
 </div>
 
 
@@ -1852,13 +1849,6 @@ Creating fast lookup database                   Done
 A clone of openindiana-1 exists and has been updated and activated.
 On the next boot the Boot Environment openindiana-2 will be
 mounted on '/'.  Reboot when ready to switch to this updated BE.
-
-
----------------------------------------------------------------------------
-NOTE: Please review release notes posted at:
-
-http://wiki.openindiana.org/display/oi/oi_hipster
----------------------------------------------------------------------------
 ```
 
 

--- a/docs/handbook/getting-started.md
+++ b/docs/handbook/getting-started.md
@@ -234,8 +234,8 @@ Installing OpenIndiana on unsupported hardware may cause excessive CPU usage, in
 Please be sure to consult the hardware compatibility list (HCL):
 
 * [Illumos HLC](https://www.illumos.org/hcl/)
-* [OpenIndiana HCL - components](../community-hcl/components)
-* [OpenIndiana HCL - systems](../community-hcl/systems)
+* [OpenIndiana HCL - components](/community-hcl/components)
+* [OpenIndiana HCL - systems](/community-hcl/systems)
 
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,10 +14,6 @@
     <div class="panel-body"><ul><li>Primary web presence</li></ul></div>
   </div>
   <div class="panel panel-default">
-    <div class="panel-heading"><a href="https://wiki.openindiana.org">wiki.openindiana.org</a></div>
-    <div class="panel-body"><ul><li>Development and community information</li></ul></div>
-  </div>
-  <div class="panel panel-default">
     <div class="panel-heading"><a href="https://illumos.org/man/">illumos Man Pages</a></div>
     <div class="panel-body"><ul><li>Man pages for the core source tree</li></ul></div>
   </div>


### PR DESCRIPTION
There are still some references and links to the old Wiki which should have been updated previously. Some mentions of the Wiki remain, but only as notes in relation to migrating old content.