### PR TITLE
Fix gh-pages deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,17 +8,17 @@ on:
 jobs:
   build-pdf:
     name: Create PDFs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install Deps
         run: |
           sudo apt-get update
           sudo apt-get install texlive-xetex fonts-noto-core
-          wget https://github.com/jgm/pandoc/releases/download/2.11.4/pandoc-2.11.4-1-amd64.deb
+          wget -nv https://github.com/jgm/pandoc/releases/download/2.11.4/pandoc-2.11.4-1-amd64.deb
           sudo apt-get install ./pandoc-2.11.4-1-amd64.deb
 
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Change to repository & Build PDFs
         run: | 
@@ -27,49 +27,53 @@ jobs:
 
       - name: Upload PDF Artifact
         if: ${{ github.event_name == 'push' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: PDFs
           path: pdf
           if-no-files-found: error
 
-  build-mkdocs-only:
-    name: Build docs
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout main
-        uses: actions/checkout@v2
-
-      - name: Build mkdocs
-        uses: OpenIndiana/mkdocs-deploy-gh-pages@oi
-        env:
-          CONFIG_FILE: mkdocs.yml
-          EXTRA_PACKAGES: build-base
-
-  build-mkdocs-and-deploy:
-    name: Build & Deploy docs
-    if: ${{ github.event_name == 'push' }}
+  build-mkdocs-conditional-deploy:
+    name: Build & conditionally deploy docs
     needs: [build-pdf]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+         python-version: '3.9'
+         cache: 'pip'
 
       - name: Create dir for PDFs
         run: mkdir docs/pdf
 
       - name: Download PDF Artifact
-        uses: actions/download-artifact@v2
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/download-artifact@v3
         with:
           name: PDFs
           path: docs/pdf/
 
-      - name: Build & Deploy mkdocs
-        uses: OpenIndiana/mkdocs-deploy-gh-pages@oi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CUSTOM_DOMAIN: docs.openindiana.org
-          CONFIG_FILE: mkdocs.yml
-          EXTRA_PACKAGES: build-base
-          PUBLISH: yes
+      - name: Install Lint Dependencies
+        run: sudo gem install mdl -v 0.4.0
+
+      - name: Lint Markdown
+        run: mdl -s markdownlint-rules.rb
+
+      - name: Install mkdocs Dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build mkdocs
+        run: mkdocs build
+
+      - name: Deploy mkdocs
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+          mkdocs gh-deploy --verbose


### PR DESCRIPTION
Our gh-pages deployment workflow relies on the `mkdocs-deploy-gh-pages` action. Since a recent change to Cython, which is a dependency of the `PyYAML` pip dependency, the wheel build inside the container for this action for this fails. [See these logs for the error](https://github.com/OpenIndiana/oi-docs/actions/runs/5706696076/job/15462963353).

This problem is preventing any further deployment of these docs. The solution is to use the built wheel for this dependency from pypi, avoiding any wheel build failures. This requires the Python version to be set to 3.9 (GitHub default is now 3.10). The `mkdocs-deploy-gh-pages` action also runs inside its own container complicating maintenance and these fixes.

Instead of trying to fix that 3rd party action, this PR removes it and does the deployment directly from the workflow in this repo. This will make maintenance and understanding how the deployment works (e.g linting) easier. It will also speed up the build as the `setup-python` action caches pip dependencies for future runs.