### PR TITLE
TeX Live: add link to custom binaries document

### DIFF
--- a/docs/handbook/community/texlive.md
+++ b/docs/handbook/community/texlive.md
@@ -105,6 +105,13 @@ This is incorrect, but it may work in some cases.  Because OpenIndiana and Solar
 ```none
 # ./install-tl --repository https://texlive.info/tlnet-archive/2023/10/10/tlnet/
 ```
+It is also possible to download custom binaries, and install and use TeX Live with binaries that are not part of the original distribution :
+
+```none
+# ./install-tl --custom-bin=/tmp/foobin
+```
+
+See the instructions at [http://tug.org/texlive/custom-bin.html](http://tug.org/texlive/custom-bin.html) for detailed information.
 
 The main menus in interactive mode are :
 


### PR DESCRIPTION

option for the install-tl script to use custom binaries from the maintainers of Tex Live