### PR TITLE
Update links to websites about pkgsrc

### DIFF
--- a/docs/handbook/getting-started.md
+++ b/docs/handbook/getting-started.md
@@ -2054,8 +2054,8 @@ Here are some of the available tools:
         * [pkgsrc](https://pkgsrc.org/)
           ([wiki page](https://wiki.openindiana.org/oi/pkgsrc+in+OI),
           [NetBSD wiki page](https://wiki.netbsd.org/pkgsrc/how_to_use_pkgsrc_on_solaris/))
-        * [Joyent's pkgsrc binary packages](https://pkgsrc.joyent.com/)
-          ([install on illumos](https://pkgsrc.joyent.com/install-on-illumos/),
+        * [MNX's pkgsrc binary packages](https://pkgsrc.smartos.org/)
+          ([install on illumos](https://pkgsrc.smartos.org/install-on-illumos/),
           [wiki page](https://wiki.openindiana.org/oi/3.+Installing+software+and+package+management))
         * [opencsw](http://sfe.opencsw.org/)
         * [SFE (spec-files-extra)](http://pkgbuild.sourceforge.net/spec-files-extra/)
@@ -2075,7 +2075,7 @@ Here are some of the available tools:
 
 In addition to IPS and SVR4 package management tools, it is also possible to use `pkgsrc`.
 
-For more information about pkgsrc, see the [Joyent package source website](https://pkgsrc.joyent.com/).
+For more information about pkgsrc, see the [MNX pkgsrc website](https://pkgsrc.smartos.org/).
 
 <div class="caution" markdown="1">
 !!! danger "Caution"

--- a/docs/misc/openindiana.md
+++ b/docs/misc/openindiana.md
@@ -35,7 +35,7 @@ Although powerful, it may seem complicated at first; but, help is provided in th
 
 OpenIndiana supports a wide range of popular software, including the main open source Internet server software, databases, Internet client software, development languages and tools and more.
 The Popular Software provides some links and notes about some of the community favorites, but many more are supported.
-In addition to the Hipster IPS repositories, OpenIndiana can also use the [SFE](http://sfe.opencsw.org/) and [pkgsrc](https://pkgsrc.joyent.com/) package repositories which provide additional software options.
+In addition to the Hipster IPS repositories, OpenIndiana can also use the [SFE](http://sfe.opencsw.org/) and [pkgsrc](https://pkgsrc.smartos.org/) package repositories which provide additional software options.
 
 
 ## What is OpenIndiana Project?


### PR DESCRIPTION
Joyent's site is no longer online -- refer to MNX's instead.

I have already made similar changes to illumos' own documentation: https://github.com/illumos/docs/pull/94