### PR TITLE
Update KVM config

### DIFF
--- a/docs/handbook/getting-started.md
+++ b/docs/handbook/getting-started.md
@@ -575,7 +575,7 @@ See the notes below for optimizing OpenIndiana for several popular hypervisors.
 | --- | ---
 | Virtualbox | OS type = Solaris 11 64-bit
 | Vmware player | OS type = Solaris 11 64-bit
-| KVM | OS type = Sun OpenSolaris <br>Disk = SATA <br>Remove USB Tablet <br>NIC = e1000 <br>sound = AC97 <br>Processor = Copy host CPU configuration <br>Disable CPU feature _'xsave'_ <br>Video = VMVGA; may not be shown in virt-manager, edit XML to be as:<br/> <code>&lt;model type='vmvga' vram='131072' heads='1' primary='yes'/&gt;</code> <br>Display = VNC (Spice not supported)
+| KVM | OS type = Generic Linux 2024 <br>Chipset = i440FX<br>sound = AC97 <br>Video = VMVGA; may not be shown in virt-manager, edit XML to be as:<br/> <code>&lt;model type='vmvga' vram='131072' heads='1' primary='yes'/&gt;</code> <br>Firmware = UEFI (legacy BIOS won't work!)
 | Hyper-V | Select single CPU, generation 1 VM, and legacy NIC.
 
 <div class="note" markdown="1">


### PR DESCRIPTION
I recently tested OpenIndiana 2025.10 under KVM, and with the following configuration, it actually works pretty well in my opinion. I therefore have decided to update docs to reflect that right here.

The base configuration used is Generic Linux 2024. You need to make the following modification for OpenIndiana to work:

- Chipset must be i440FX (otherwise neither the hard drive nor the ethernet adapter are detected for some reason)
- Video adapter must be 'vmvga' with the custom XML
- Sound must be AC97 (kept from the previous docs)
- Firmware must be UEFI

Note that I can neither confirm nor deny if xsave instructions play any role. They might if under the legacy BIOS, but apparently under UEFI, they don't matter. Therefore, I decided to remove that mention, but it can be restored if necessary. I also haven't tested sound yet, so I'm keeping the recommendation to use AC97 for now.